### PR TITLE
BLD: Setting ophyd to be version 0.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ git+https://github.com/slaclab/lightpath#egg=lightpath
 git+https://github.com/slaclab/pcds-devices#egg=pcds-devices
 git+https://github.com/slaclab/pswalker#egg=pswalker
 super_state_machine
-ophyd 
+ophyd==0.6.1


### PR DESCRIPTION
Addressing the `prettytable` issue by setting ophyd to be `0.6.1`.