### PR TITLE
ENH: Adding classes for pneumatics

### DIFF
--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -168,9 +168,9 @@ class PressureSwitch(PneuBase):
             String saying the current position of the valve. Can be "OPEN" or
             "CLOSED". 
         """
-        if self.valve.value ==0:
+        if self.pressure.value == 0:
             return "GOOD"
-        elif self.valve.value == 1:
+        elif self.pressure.value == 1:
             return "BAD"
 
     @property
@@ -183,7 +183,7 @@ class PressureSwitch(PneuBase):
         good : bool
             True if the pressure switch is in the 'good' state.
         """
-        return (self.position == "OPEN")
+        return (self.position == "GOOD")
 
     @property
     def bad(self):
@@ -195,6 +195,6 @@ class PressureSwitch(PneuBase):
         bad : bool
             True if the pressure switch is in the 'bad' state.
         """
-        return (self.position == "OPEN")
+        return (self.position == "BAD")
 
     

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -22,18 +22,70 @@ from pcdsdevices.epics.signal import EpicsSignal, EpicsSignalRO
 
 logger = logging.getLogger(__name__)
 
-
-class ProportionalValve(Device):
+class PneuBase(Device):
     """
-    Class for the proportional pneumatic valves.
+    Base class for the penumatics.
     """
-    valve = Component(EpicsSignal, ":VGP")
 
     def __init__(self, prefix, desc=None, *args, **kwargs):
         self.desc=desc
         super().__init__(prefix, *args, **kwargs)
         if desc is None:
             self.desc = self.name    
+    
+    def status(self, status="", offset=0, print_status=True, newline=False):
+        """
+        Returns the status of the device.
+
+        Parameters
+        ----------
+        status : str, optional
+            The string to append the status to.
+            
+        offset : int, optional
+            Amount to offset each line of the status.
+
+        print_status : bool, optional
+            Determines whether the string is printed or returned.
+
+        newline : bool, optional
+            Adds a new line to the end of the string.
+
+        Returns
+        -------
+        status : str
+            Status string.
+        """
+        status += "{0}{1}: {3}\n".format(" "*offset, self.desc, self.position)
+        if newline:
+            status += "\n"
+        if print_status is True:
+            print(status)
+        else:
+            return status
+
+    def __repr__(self):
+        """
+        Returns the status of the valve. Alias for status().
+
+        Returns
+        -------
+        status : str
+            Status string.
+        """
+        return self.status(print_status=False)
+
+
+class ProportionalValve(PneuBase):
+    """
+    Class for the proportional pneumatic valves.
+
+    Components
+    ----------
+    valve : EpicsSignal
+        Valve control and readback pv.
+    """
+    valve = Component(EpicsSignal, ":VGP")
 
     def open(self):
         """
@@ -92,54 +144,57 @@ class ProportionalValve(Device):
             True if the valve is currently in the 'closed' position.
         """
         return (self.position == "CLOSED")
+    
 
-    def status(self, status="", offset=0, print_status=True, newline=False):
-        """
-        Returns the status of the valve.
-
-        Parameters
-        ----------
-        status : str, optional
-            The string to append the status to.
-            
-        offset : int, optional
-            Amount to offset each line of the status.
-
-        print_status : bool, optional
-            Determines whether the string is printed or returned.
-
-        newline : bool, optional
-            Adds a new line to the end of the string.
-
-        Returns
-        -------
-        status : str
-            Status string.
-        """
-        status += "{0}{1}: {3}\n".format(" "*offset, self.desc, self.position)
-        if newline:
-            status += "\n"
-        if print_status is True:
-            print(status)
-        else:
-            return status
-
-    def __repr__(self):
-        """
-        Returns the status of the valve. Alias for status().
-
-        Returns
-        -------
-        status : str
-            Status string.
-        """
-        return self.status(print_status=False)
-        
-
-class PressureSwitch(Device):
+class PressureSwitch(PneuBase):
     """
     Pressure switch.
+
+    Components
+    ----------
+    pressure : EpicsSignalRO
+        Pressure readbac signal.
     """
     pressure = Component(EpicsSignalRO, ":GPS")
+        
+    @property
+    def position(self):
+        """
+        Returns the position of the valve.
+
+        Returns
+        -------
+        position : str
+            String saying the current position of the valve. Can be "OPEN" or
+            "CLOSED". 
+        """
+        if self.valve.value ==0:
+            return "GOOD"
+        elif self.valve.value == 1:
+            return "BAD"
+
+    @property
+    def good(self):
+        """
+        Returns if the pressure is in the 'good' state.
+
+        Returns
+        -------
+        good : bool
+            True if the pressure switch is in the 'good' state.
+        """
+        return (self.position == "OPEN")
+
+    @property
+    def bad(self):
+        """
+        Returns if the pressure is in the 'bad' state.
+
+        Returns
+        -------
+        bad : bool
+            True if the pressure switch is in the 'bad' state.
+        """
+        return (self.position == "OPEN")
 
     

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -120,6 +120,8 @@ class ProportionalValve(PneuBase):
             return "OPEN"
         elif self.valve.value == 0:
             return "CLOSED"
+        else:
+            return "UNKNOWN"
 
     @property
     def opened(self):
@@ -172,6 +174,8 @@ class PressureSwitch(PneuBase):
             return "GOOD"
         elif self.pressure.value == 1:
             return "BAD"
+        else:
+            return "UNKNOWN"
 
     @property
     def good(self):

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Pneumatics for SnD
+"""
+############
+# Standard #
+############
+import logging
+
+###############
+# Third Party #
+###############
+import numpy as np
+
+########
+# SLAC #
+########
+from pcdsdevices.device import Device
+from pcdsdevices.component import Component
+from pcdsdevices.epics.signal import EpicsSignal, EpicsSignalRO
+
+logger = logging.getLogger(__name__)
+
+
+class ProportionalValve(Device):
+    """
+    Class for the proportional pneumatic valves.
+    """
+    valve = Component(EpicsSignal, ":VGP")
+
+    def __init__(self, prefix, desc=None, *args, **kwargs):
+        self.desc=desc
+        super().__init__(prefix, *args, **kwargs)
+        if desc is None:
+            self.desc = self.name    
+
+    def open(self):
+        """
+        Closes the valve.
+        """
+        if self.opened:
+            logger.info("Valve currently open.")
+        else:
+            self.valve.put(1)
+    
+    def close(self):
+        """
+        Closes the valve.
+        """
+        if self.closed:
+            logger.info("Valve currently closed.")
+        else:
+            self.valve.put(0)
+        
+    @property
+    def position(self):
+        """
+        Returns the position of the valve.
+
+        Returns
+        -------
+        position : str
+            String saying the current position of the valve. Can be "OPEN" or
+            "CLOSED". 
+        """
+        if self.valve.value == 1:
+            return "OPEN"
+        elif self.valve.value == 0:
+            return "CLOSED"
+
+    @property
+    def opened(self):
+        """
+        Returns if the valve is in the opened state.
+
+        Returns
+        -------
+        opened : bool
+            True if the valve is currently in the 'opened' position.
+        """
+        return (self.position == "OPEN")
+
+    @property
+    def closed(self):
+        """
+        Returns if the valve is in the closed state.
+
+        Returns
+        -------
+        closed : bool
+            True if the valve is currently in the 'closed' position.
+        """
+        return (self.position == "CLOSED")
+
+    def status(self, status="", offset=0, print_status=True, newline=False):
+        """
+        Returns the status of the valve.
+
+        Parameters
+        ----------
+        status : str, optional
+            The string to append the status to.
+            
+        offset : int, optional
+            Amount to offset each line of the status.
+
+        print_status : bool, optional
+            Determines whether the string is printed or returned.
+
+        newline : bool, optional
+            Adds a new line to the end of the string.
+
+        Returns
+        -------
+        status : str
+            Status string.
+        """
+        status += "{0}{1}: {3}\n".format(" "*offset, self.desc, self.position)
+        if newline:
+            status += "\n"
+        if print_status is True:
+            print(status)
+        else:
+            return status
+
+    def __repr__(self):
+        """
+        Returns the status of the valve. Alias for status().
+
+        Returns
+        -------
+        status : str
+            Status string.
+        """
+        return self.status(print_status=False)
+        
+
+class PressureSwitch(Device):
+    """
+    Pressure switch.
+    """
+    pressure = Component(EpicsSignalRO, ":GPS")
+
+    

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -555,19 +555,19 @@ class Vacuum(SndDevice):
     Components
     ----------
     t1_valve : ProportionalValve
-        Proportional valve on T1
+        Proportional valve on T1.
 
     t4_valve : ProportionalValve
-        Proportional valve on T4
+        Proportional valve on T4.
 
     vac_valve : ProportionalValve
         Proportional valve on the overall system.
 
     t1_pressure : PressureSwitch
-        Pressure switch on T1
+        Pressure switch on T1.
 
     t4_pressure : PressureSwitch
-        Pressure switch on T4
+        Pressure switch on T4.
 
     vac_pressure : PressureSwitch
         Pressure switch on the overall system.
@@ -603,7 +603,7 @@ class Vacuum(SndDevice):
         status : str
             Status string.
         """
-        status += "{0}Vacuum\n{1}{2}".format(" "*offset, " "*offset, "-"*6)
+        status += "{0}Vacuum\n{1}{2}\n".format(" "*offset, " "*offset, "-"*6)
         status += self.t1_valve.status(status, offset+2, print_status=False,
                                        newline=True)
         status += self.t4_valve.status(status, offset+2, print_status=False,
@@ -615,8 +615,14 @@ class Vacuum(SndDevice):
         status += self.t4_pressure.status(status, offset+2, print_status=False,
                                           newline=True)
         status += self.vac_pressure.status(status, offset+2, print_status=False,
-                                           newline=True)
-    
+                                           newline=False)
+        
+        if newline:
+            status += "\n"
+        if print_status is True:
+            print(status)
+        else:
+            return status
 
 class SplitAndDelay(SndDevice):
     """

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -32,6 +32,7 @@ from .attocube import (EccBase, TranslationEcc, GoniometerEcc,
                                         DiodeEcc)
 from .diode import (HamamatsuDiode, HamamatsuXMotionDiode,
                                      HamamatsuXYMotionCamDiode)
+from .pneumatic import (ProportionalValve, PressureSwitch)
 
 logger = logging.getLogger(__name__)
 
@@ -532,7 +533,25 @@ class ChannelCutTower(TowerBase):
         status = self.th.move(theta/2, wait=wait)
         return status
 
-        
+
+class Vacuum(Device):
+    """
+    Class that contains the various pneumatic components of the system.
+    """
+    t1_valve = Component(ProportionalValve, ":N2:T1")
+    t4_valve = Component(ProportionalValve, ":N2:T4")
+    vac_valve = Component(ProportionalValve, ":VAC")
+
+    # t1_pressure = Component(PressureSwitch, ":N2:T1")
+    # t4_pressure = Component(PressureSwitch, ":N2:T4")
+    # vac_pressure = Component(PressureSwitch, ":VAC")
+
+    # def status(self, status="", offset=0, print_status=True, newline=False):
+    #     """
+    #     Returns the status of the system.
+    #     """
+    #     status += "{0}Valves
+
 class SplitAndDelay(Device):
     """
     Hard X-Ray Split and Delay System.
@@ -582,6 +601,9 @@ class SplitAndDelay(Device):
                    pos_removed=0, desc="Tower 2")
     t3 = Component(ChannelCutTower, ":T3", pos_inserted=None, 
                    pos_removed=0, desc="Tower 3")
+
+    # Vacuum
+    vacuum = Component(Vacuum, "")
 
     # SnD and Delay line diodes
     di = Component(HamamatsuXYMotionCamDiode, ":DIA:DI")
@@ -841,7 +863,7 @@ class SplitAndDelay(Device):
         
         Returns
         -------
-        status : str            
+        Status : str            
         """
         status =  "Split and Delay System Status\n"
         status += "-----------------------------\n"

--- a/hxrsnd/tests/test_pneumatic.py
+++ b/hxrsnd/tests/test_pneumatic.py
@@ -22,6 +22,7 @@ from pcdsdevices.sim.pv import using_fake_epics_pv
 # Module #
 ##########
 from hxrsnd import pneumatic
+from hxrsnd.pneumatic import ProportionalValve, PressureSwitch
 from .conftest import get_classes_in_module
 
 logger = logging.getLogger(__name__)
@@ -34,3 +35,28 @@ def test_devices_instantiate_and_run_ophyd_functions(dev):
     assert(isinstance(device.describe(), OrderedDict))
     assert(isinstance(device.describe_configuration(), OrderedDict))
     assert(isinstance(device.read_configuration(), OrderedDict))
+
+@using_fake_epics_pv
+def test_ProportionalValve_opens_and_closes_correctly():
+    valve = ProportionalValve("TEST")
+    valve.open()
+    assert valve.position == "OPEN"
+    assert valve.opened is True
+    assert valve.closed is False
+    valve.close()
+    assert valve.position == "CLOSED"
+    assert valve.opened is False
+    assert valve.closed is True
+
+@using_fake_epics_pv
+def test_PressureSwitch_reads_correctly():
+    press = PressureSwitch("TEST")
+    press.pressure._read_pv._value = 0
+    assert press.position == "GOOD"
+    assert press.good is True
+    assert press.bad is False
+    press.pressure._read_pv._value = 1
+    assert press.position == "BAD"
+    assert press.good is False
+    assert press.bad is True
+    

--- a/hxrsnd/tests/test_pneumatic.py
+++ b/hxrsnd/tests/test_pneumatic.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+############
+# Standard #
+############
+import logging
+from collections import OrderedDict
+import pytest
+
+###############
+# Third Party #
+###############
+import numpy as np
+from ophyd.device import Device
+
+########
+# SLAC #
+########
+from pcdsdevices.sim.pv import using_fake_epics_pv
+
+##########
+# Module #
+##########
+from hxrsnd import pneumatic
+from .conftest import get_classes_in_module
+
+logger = logging.getLogger(__name__)
+
+@using_fake_epics_pv
+@pytest.mark.parametrize("dev", get_classes_in_module(pneumatic, Device))
+def test_devices_instantiate_and_run_ophyd_functions(dev):
+    device = dev("TEST")
+    assert(isinstance(device.read(), OrderedDict))
+    assert(isinstance(device.describe(), OrderedDict))
+    assert(isinstance(device.describe_configuration(), OrderedDict))
+    assert(isinstance(device.read_configuration(), OrderedDict))

--- a/hxrsnd/tests/test_sndsystem.py
+++ b/hxrsnd/tests/test_sndsystem.py
@@ -23,6 +23,7 @@ from pcdsdevices.sim.pv import using_fake_epics_pv
 # Module #
 ##########
 from hxrsnd import sndsystem
+from hxrsnd.sndsystem import SndVacuum
 from .conftest import get_classes_in_module
 from hxrsnd.sndsystem import DelayTower, ChannelCutTower
 from hxrsnd.exceptions import MotorDisabled, MotorFaulted
@@ -73,4 +74,14 @@ def test_ChannelCutTower_does_not_move_if_motors_not_ready():
     with pytest.raises(MotorFaulted):
         tower.energy = 10
 
-        
+@using_fake_epics_pv    
+def test_SndVacuum_open_and_close_methods():
+    vac = SndVacuum("TEST")
+    for valve in vac._valves:
+        valve.close()
+    vac.open()
+    for valve in vac._valves:
+        assert valve.opened
+    vac.close()
+    for valve in vac._valves:
+        assert valve.closed


### PR DESCRIPTION
Overview
------------
PR adds classes to control the pneumatic devices of the system. This includes the proportional valves and pressure switches on towers 1 and 4, in addition to the system level valve and switch. The classes that map to these two devices are in `pneumatic.py` and are `ProportionalValve` and `PressureSwitch` respectively. I initially wanted to split off the components to each of the towers and then the last pair at the `SplitAndDelay` level, but as per Diling's request, I organized the vacuum components into their own high-level device called `SndVacuum`. There were also some changes made to better organize the methods of the high-level classes in `sndsytem.py`. Tests were written for all the new classes.

Pneumatic Classes
------------
`PneuBase` - Base class for the pneumatic devices
`ProportionalValve` - Class for the proportional valve that has methods to open and close the valve, as well as properties to make reading back the status easy.
`PressureSwitch` - Class for the pressure switches that also has properties for returning the pressure status.

New SnD Classes
----------
`SndDevice` - New base-level class that all the other higher-level ones inherit from.`__repr__` and `desc` attributes are defined here.
`SndVacuum` - High-level vacuum device that has all the proportional valves and pressure switches as components. Included are methods to open or close all the valves, in addition to reading back the status of the components.