### PR TITLE
ENH: Optionally return status objects for motors. Log or print everything.

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -86,7 +86,8 @@ class AeroBase(EpicsMotor):
     def _status_print(self, status, msg=None, ret_status=False, print_set=True):
         """
         Internal method that optionally returns the status object and optionally
-        prints a message about the set.
+        prints a message about the set. If a message is passed but print_set is
+        False then the message is logged at the debug level.
 
         Parameters
         ----------
@@ -107,8 +108,11 @@ class AeroBase(EpicsMotor):
         Status
             Inputted status object.        
         """
-        if print_set and msg is not None:
-            print(msg)
+        if msg is not None:
+            if print_set:
+                logger.info(msg)
+            else:
+                logger.debug(msg)
         if ret_status:
             return status
 
@@ -206,9 +210,9 @@ class AeroBase(EpicsMotor):
             # Notify the user that a motor has completed or the command is sent
             if print_move:
                 if wait:
-                    print("Move completed for '{0}'.".format(self.desc))
+                    logger.info("Move completed for '{0}'.".format(self.desc))
                 else:
-                    print("Move command sent to '{0}'.".format(self.desc))
+                    logger.info("Move command sent to '{0}'.".format(self.desc))
             # Check if a status object is desired
             if ret_status:
                 return status
@@ -498,7 +502,7 @@ class AeroBase(EpicsMotor):
             Prints that the screen is being launched.
         """
         if print_msg:
-            print("Launching expert screen.")
+            logger.info("Launching expert screen.")
         os.system("/reg/neh/operator/xcsopr/bin/snd/expert_screen.sh {0}"
                   "".format(self.prefix))
 

--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -83,29 +83,79 @@ class AeroBase(EpicsMotor):
         if desc is None:
             self.desc = self.name
 
-    def homf(self):
+    def _status_print(self, status, msg=None, ret_status=False, print_set=True):
+        """
+        Internal method that optionally returns the status object and optionally
+        prints a message about the set.
+
+        Parameters
+        ----------
+        status : StatusObject
+            The inputted status object.
+        
+        msg : str or None, optional
+            Message to print if print_set is True.
+
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
+        Returns
+        -------
+        Status
+            Inputted status object.        
+        """
+        if print_set and msg is not None:
+            print(msg)
+        if ret_status:
+            return status
+
+    def homf(self, ret_status=False, print_set=True):
         """
         Home the motor forward.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
         
         Returns
         -------
         Status : StatusObject
             Status of the set.
         """
-        return self.home_forward.set(1)
+        status = self.home_forward.set(1)
+        return self._status_print(status, "Homing '{0}' forward.".format(
+            self.desc))
 
-    def homr(self):
+    def homr(self, ret_status=False, print_set=True):
         """
         Home the motor in reverse.
         
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
         Returns
         -------
         Status : StatusObject
             Status of the set.
         """
-        return self.home_reverse.set(1)
+        status = self.home_reverse.set(1)
+        return self._status_print(status, "Homing '{0}' in reverse.".format(
+            self.desc))
 
-    def move(self, position, wait=False, *args, **kwargs):
+    def move(self, position, wait=False, ret_status=True, print_move=False, 
+             *args, **kwargs):
         """
         Move to a specified position, optionally waiting for motion to
         complete.
@@ -115,6 +165,15 @@ class AeroBase(EpicsMotor):
         position
             Position to move to.
 
+        wait : bool, optional
+            Wait for the motor to complete the motion.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
         moved_cb : callable
             Call this callback when movement has finished. This callback must
             accept one keyword argument: 'obj' which will be set to this
@@ -123,9 +182,6 @@ class AeroBase(EpicsMotor):
         timeout : float, optional
             Maximum time to wait for the motion. If None, the default timeout
             for this positioner is used.
-
-        wait : bool, optional
-            Wait for the motor to complete the motion.
 
         Returns
         -------
@@ -146,11 +202,124 @@ class AeroBase(EpicsMotor):
         try:
             # Check the motor status
             self.check_status()
-            return super().move(position, wait=wait, *args, **kwargs)
+            status =  super().move(position, wait=wait, *args, **kwargs)
+            # Notify the user that a motor has completed or the command is sent
+            if print_move:
+                if wait:
+                    print("Move completed for '{0}'.".format(self.desc))
+                else:
+                    print("Move command sent to '{0}'.".format(self.desc))
+            # Check if a status object is desired
+            if ret_status:
+                return status
+
+        # If keyboard interrupted, make sure to stop the motor
         except KeyboardInterrupt:
             self.stop()
             logger.info("Motor '{0}' stopped by keyboard interrupt".format(
                 self.desc))
+
+    def move_rel(self, rel_position, *args, **kwargs):
+        """
+        Move relative to the current position, optionally waiting for motion to
+        complete.
+
+        Parameters
+        ----------
+        rel_position
+            Relative position to move to
+
+        wait : bool, optional
+            Wait for the motor to complete the motion.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
+        moved_cb : callable
+            Call this callback when movement has finished. This callback must
+            accept one keyword argument: 'obj' which will be set to this
+            positioner instance.
+
+        timeout : float, optional
+            Maximum time to wait for the motion. If None, the default timeout
+            for this positioner is used.
+
+        Returns
+        -------
+        status : MoveStatus        
+            Status object for the move.
+        
+        Raises
+        ------
+        TimeoutError
+            When motion takes longer than `timeout`
+        
+        ValueError
+            On invalid positions
+        
+        RuntimeError
+            If motion fails other than timing out        
+        """
+        return self.move(rel_position + self.position, *args, **kwargs)
+
+    def mv(self, position, wait=True, ret_status=False, print_move=True, 
+           *args, **kwargs):
+        """
+        Move to a specified position, optionally waiting for motion to
+        complete. Alias for move().
+
+        Parameters
+        ----------
+        position
+            Position to move to.
+
+        wait : bool, optional
+            Wait for the motor to complete the motion.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
+        Returns
+        -------
+        status : MoveStatus        
+            Status object for the move.
+        """
+        return self.move(position, wait=wait, ret_status=ret_status, 
+                         print_move=print_move, *args, **kwargs)
+
+    def mvr(self, rel_position, wait=True, ret_status=False, print_move=True, 
+            *args, **kwargs):
+        """
+        Move relative to the current position, optionally waiting for motion to
+        complete. Alias for move_rel().
+
+        Parameters
+        ----------
+        rel_position
+            Relative position to move to.
+
+        wait : bool, optional
+            Wait for the motor to complete the motion.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
+        Returns
+        -------
+        status : MoveStatus        
+            Status object for the move.
+        """
+        return self.move_rel(rel_position, wait=wait, ret_status=ret_status, 
+                             print_move=print_status, *args, **kwargs)
 
     def check_status(self):
         """
@@ -190,27 +359,47 @@ class AeroBase(EpicsMotor):
         logger.info("New position: {0}, offset: {1}".format(
             self.position, self.offset))
 
-    def enable(self):
+    def enable(self, ret_status=False, print_set=True):
         """
         Enables the motor power.
 
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
         Returns
         -------
         Status
             The status object for setting the power signal.
         """
-        return self.power.set(1)
+        status = self.power.set(1)
+        return self._status_print(status, "Enabled motor '{0}'.".format(
+            self.desc))
 
-    def disable(self):
+    def disable(self, ret_status=False, print_set=True):
         """
         Disables the motor power.
 
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
         Returns
         -------
         Status
             The status object for setting the power signal.
         """
-        return self.power.set(0)
+        status = self.power.set(0)
+        return self._status_print(status, "Disabled motor '{0}'.".format(
+            self.desc))
 
     @property
     def enabled(self):
@@ -224,27 +413,47 @@ class AeroBase(EpicsMotor):
         """
         return bool(self.power.value)
 
-    def clear(self):
+    def clear(self, ret_status=False, print_set=True):
         """
         Clears the motor error.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
 
         Returns
         -------
         Status
             The status object for setting the clear_error signal.
         """
-        return self.clear_error.set(1)
+        status = self.clear_error.set(1)
+        return self._status_print(status, "Cleared motor '{0}'.".format(
+            self.desc))
 
-    def reconfig(self):
+    def reconfig(self, ret_status=False, print_set=True):
         """
         Re-configures the motor.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
 
         Returns
         -------
         Status
             The status object for setting the config signal.
         """
-        return self.config.set(1)
+        status = self.config.set(1)
+        return self._status_print(status, "Reconfigured motor '{0}'.".format(
+            self.desc))
 
     @property
     def faulted(self):
@@ -258,25 +467,43 @@ class AeroBase(EpicsMotor):
         """
         return bool(self.axis_fault.value)
     
-    def zero_all(self):
+    def zero_all(self, ret_status=False, print_set=True):
         """
         Sets the current position to be the zero position of the motor.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
 
         Returns
         -------
         status : StatusObject        
             Status object for the set.
         """
-        self.zero_all_proc.set(1)
+        status = self.zero_all_proc.set(1)
+        return self._status_print(status, "Zeroed motor '{0}'.".format(
+            self.desc))
 
-    def expert_screen(self):
+    def expert_screen(self, print_msg=True):
         """
         Launches the expert screen for the motor.
+
+        Parameters
+        ----------
+        print_msg : bool, optional
+            Prints that the screen is being launched.
         """
+        if print_msg:
+            print("Launching expert screen.")
         os.system("/reg/neh/operator/xcsopr/bin/snd/expert_screen.sh {0}"
                   "".format(self.prefix))
 
-    def __call__(self, position, *args, **kwargs):
+    def __call__(self, position, wait=True, ret_status=False, print_move=True,
+                 *args, **kwargs):
         """
         Moves the motor to the inputted position. Alias for self.move(position).
 
@@ -285,12 +512,22 @@ class AeroBase(EpicsMotor):
         position
             Position to move to.
 
+        wait : bool, optional
+            Wait for the motor to complete the motion.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
         Returns
         -------
-        status : MoveStatus        
-            Status object for the move.        
+        status : MoveStatus 
+            Status object for the move.
         """
-        return self.move(position, *args, **kwargs)
+        return self.move(position, wait=wait, ret_status=ret_status,
+                         print_move=print_move, *args, **kwargs)
     
     def status(self, status="", offset=0, print_status=True, newline=False):
         """

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -121,27 +121,76 @@ class EccBase(Device, PositionerBase):
         """
         return self.motor_egu.get()
 
-    def enable(self):
+    def _status_print(self, status, msg=None, ret_status=False, print_set=True):
+        """
+        Internal method that optionally returns the status object and optionally
+        prints a message about the set.
+
+        Parameters
+        ----------
+        status : StatusObject
+            The inputted status object.
+        
+        msg : str or None, optional
+            Message to print if print_set is True.
+
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
+        Returns
+        -------
+        Status
+            Inputted status object.        
+        """
+        if print_set and msg is not None:
+            print(msg)
+        if ret_status:
+            return status
+
+    def enable(self, ret_status=False, print_set=True):
         """
         Enables the motor power.
 
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
         Returns
         -------
         Status
             The status object for setting the power signal.
         """
-        return self.motor_enable.set(1)
+        status = self.motor_enable.set(1)
+        return self._status_print(status, "Enabled motor '{0}'".format(
+            self.desc))
 
-    def disable(self):
+    def disable(self, ret_status=False, print_set=True):
         """
         Disables the motor power.
 
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
+
         Returns
         -------
         Status
             The status object for setting the power signal.
         """
-        return self.motor_enable.set(0)
+        status = self.motor_enable.set(0)
+        return self._status_print(status, "Disabled motor '{0}'".format(
+            self.desc))
 
     @property
     def enabled(self):
@@ -191,7 +240,7 @@ class EccBase(Device, PositionerBase):
         """
         return bool(self.motor_error.value)
 
-    def reset(self):
+    def reset(self, ret_status=False, print_set=True):
         """
         Sets the current position to be the zero position of the motor.
 
@@ -200,10 +249,12 @@ class EccBase(Device, PositionerBase):
         status : StatusObject        
             Status object for the set.
         """
-        self.motor_reset.set(1)
+        status = self.motor_reset.set(1)
+        return self._status_print(status, "Reset motor '{0}'".format(
+            self.desc))
     
-    
-    def move(self, position, *args, **kwargs):
+    def move(self, position, ret_status=True, print_move=False, *args, 
+             **kwargs):
         """
         Move to a specified position.
 
@@ -212,14 +263,11 @@ class EccBase(Device, PositionerBase):
         position
             Position to move to
 
-        moved_cb : callable
-            Call this callback when movement has finished. This callback must
-            accept one keyword argument: 'obj' which will be set to this
-            positioner instance.
+        ret_status : bool, optional
+            Return the status object of the move.
 
-        timeout : float, optional
-            Maximum time to wait for the motion. If None, the default timeout
-            for this positioner is used.
+        print_move : bool, optional
+            Print a short statement about the move.
 
         Returns
         -------
@@ -246,7 +294,13 @@ class EccBase(Device, PositionerBase):
 
         # Begin the move process
         status = self.user_setpoint.set(position)
-        return status
+
+        # Notify the user that a motor has completed or the command is sent
+        if print_move:
+            print("Move command sent to '{0}'.".format(self.desc))
+        # Check if a status object is desired
+        if ret_status:
+            return status
 
     def check_status(self):
         """
@@ -297,9 +351,17 @@ class EccBase(Device, PositionerBase):
                                        self.high_limit))
             raise LimitError(err_str)
 
-    def stop(self, *, success=False):
+    def stop(self, success=False, ret_status=False, print_set=True):
         """
         Stops the motor.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_move : bool, optional
+            Print a short statement about the set.
 
         Returns
         -------
@@ -308,7 +370,11 @@ class EccBase(Device, PositionerBase):
         """
         status = self.motor_stop.set(1, wait=False)
         super().stop(success=success)
-        return status
+
+        if print_set:
+            print("Stopped motor '{0}'.".format(self.desc))
+        if ret_status:
+            return status
         
     def move_rel(self, rel_position, *args, **kwargs):
         """
@@ -320,14 +386,11 @@ class EccBase(Device, PositionerBase):
         rel_position
             Relative position to move to
 
-        moved_cb : callable
-            Call this callback when movement has finished. This callback must
-            accept one keyword argument: 'obj' which will be set to this
-            positioner instance.
+        ret_status : bool, optional
+            Return the status object of the move.
 
-        timeout : float, optional
-            Maximum time to wait for the motion. If None, the default timeout
-            for this positioner is used.
+        print_move : bool, optional
+            Print a short statement about the move.
 
         Returns
         -------
@@ -347,29 +410,54 @@ class EccBase(Device, PositionerBase):
         """
         return self.move(rel_position + self.position, *args, **kwargs)
 
-    def mv(self, position, *args, **kwargs):
+    def mv(self, position, ret_status=False, print_move=True, *args, **kwargs):
         """
         Move to a specified position, optionally waiting for motion to
         complete. Alias for move().
 
+        Parameters
+        ----------
+        position
+            Position to move to.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
         Returns
         -------
         status : MoveStatus        
             Status object for the move.
         """
-        return self.move(position, *args, **kwargs)
+        return self.move(position, ret_status=ret_status, print_move=print_move,
+                         *args, **kwargs)
 
-    def mvr(self, rel_position, *args, **kwargs):
+    def mvr(self, rel_position, ret_status=False, print_move=True, *args, 
+            **kwargs):
         """
         Move relative to the current position, optionally waiting for motion to
         complete. Alias for move_rel().
 
+        Parameters
+        ----------
+        rel_position
+            Relative position to move to.
+
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
         Returns
         -------
         status : MoveStatus        
             Status object for the move.
         """
-        return self.move_rel(rel_position, *args, **kwargs)
+        return self.move_rel(rel_position, ret_status=ret_status, 
+                             print_move=print_move, *args, **kwargs)
 
     def wm(self):
         """
@@ -392,6 +480,20 @@ class EccBase(Device, PositionerBase):
         axis = act[3:]
         os.system("/reg/neh/operator/xcsopr/bin/snd/expert_screen.sh {0} {1}"
                   "".format(p, axis))
+
+    def set_limits(self, llm, hlm):
+        """
+        Sets the limits of the motor. Alias for limits = (llm, hlm).
+        
+        Parameters
+        ----------
+        llm : float
+            Desired low limit.
+            
+        hlm : float
+            Desired low limit.
+        """        
+        self.limits = (llm, hlm)
 
     @property
     def high_limit(self):
@@ -448,7 +550,9 @@ class EccBase(Device, PositionerBase):
         self.low_limit = value[0]
         self.high_limit = value[1]
 
-    def __call__(self, position, *args, **kwargs):
+
+    def __call__(self, position, ret_status=False, print_move=True, *args, 
+                 **kwargs):
         """
         Moves the motor to the inputted position. Alias for self.move(position).
 
@@ -457,12 +561,19 @@ class EccBase(Device, PositionerBase):
         position
             Position to move to.
 
+        ret_status : bool, optional
+            Return the status object of the move.
+
+        print_move : bool, optional
+            Print a short statement about the move.
+
         Returns
         -------
-        status : MoveStatus        
-            Status object for the move.        
+        status : MoveStatus 
+            Status object for the move.
         """
-        return self.move(position, *args, **kwargs)        
+        return self.move(position, ret_status=ret_status, print_move=print_move,
+                         *args, **kwargs)
 
     def status(self, status="", offset=0, print_status=True, newline=False):
         """

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -145,8 +145,11 @@ class EccBase(Device, PositionerBase):
         Status
             Inputted status object.        
         """
-        if print_set and msg is not None:
-            print(msg)
+        if msg is not None:
+            if print_set:
+                logger.info(msg)
+            else:
+                logger.debug(msg)
         if ret_status:
             return status
 
@@ -297,7 +300,7 @@ class EccBase(Device, PositionerBase):
 
         # Notify the user that a motor has completed or the command is sent
         if print_move:
-            print("Move command sent to '{0}'.".format(self.desc))
+            logger.info("Move command sent to '{0}'.".format(self.desc))
         # Check if a status object is desired
         if ret_status:
             return status
@@ -370,11 +373,8 @@ class EccBase(Device, PositionerBase):
         """
         status = self.motor_stop.set(1, wait=False)
         super().stop(success=success)
-
-        if print_set:
-            print("Stopped motor '{0}'.".format(self.desc))
-        if ret_status:
-            return status
+        return self._status_print(status, "Stopped motor '{0}'".format(
+            self.desc))
         
     def move_rel(self, rel_position, *args, **kwargs):
         """

--- a/hxrsnd/tests/test_epics_aerotech.py
+++ b/hxrsnd/tests/test_epics_aerotech.py
@@ -52,7 +52,7 @@ def test_AeroBase_callable_moves_the_motor(position):
     motor.limits = (0, 1)
     assert motor.user_setpoint.value != position
     time.sleep(0.5)
-    motor(position)
+    motor(position, wait=False)
     time.sleep(0.1)
     assert motor.user_setpoint.value == position
 

--- a/hxrsnd/tests/test_epics_attocube.py
+++ b/hxrsnd/tests/test_epics_attocube.py
@@ -61,6 +61,6 @@ def test_EccBase_callable_moves_the_motor(position):
     motor.limits = (0, 1)
     assert motor.user_setpoint.value != position
     time.sleep(0.25)
-    motor(position)
+    motor(position, wait=False)
     time.sleep(0.1)
     assert motor.user_setpoint.value == position


### PR DESCRIPTION
Overview
-------------
Diling was complaining about status objects being returned everywhere so I made it optional for all methods that previously returned them. I have also made it so that the only methods that return a status object by default are the `move` and `rel_move` methods. *All other methods now no longer return status objects by default, this includes the aliases for `move` and `rel_move`.* Also, `EccBase` was missing a `set_limits` method, so I added it.

Returning Status Objects
---------------------------------
All methods that previously returned a status object now have two additional arguments:
- `ret_status` - Bool that determines if a status object should be returned
- `print_set` / `print_move` - Bool that determines if a short message should be printed to the console about the move or set.

With the exception of `move` and `rel_move`, all methods have `ret_status` set to `False` and `print_set` or `print_move` set to True. More importantly, this includes the aliases `mv` and `rmv`  along with `__call__` so to maintain regular functionality just use `move` and `rel_move`. 

Other / Misc.
---------------
- `EccBase` didn't have an explicit `set_limits` method so I added the same one that `AeroBase` had.