### PR TITLE
ENH: Addressing a bunch of Diling's requests

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -26,10 +26,11 @@ from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO, FakeSignal)
 ##########
 # Module #
 ##########
+from .utils import get_logger
 from .pneumatic import PressureSwitch
 from .exceptions import MotorDisabled, MotorFaulted, BadN2Pressure
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class AeroBase(EpicsMotor):

--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -76,6 +76,7 @@ class AeroBase(EpicsMotor):
     zero_all_proc = Component(EpicsSignal, ".ZERO_P.PROC")
     home_forward = Component(EpicsSignal, ".HOMF")
     home_reverse = Component(EpicsSignal, ".HOMR")
+    dial = Component(EpicsSignalRO, ".DRBV")
 
     def __init__(self, prefix, desc=None, *args, **kwargs):
         self.desc=desc
@@ -597,7 +598,8 @@ class AeroBase(EpicsMotor):
         return self.move(position, wait=wait, ret_status=ret_status,
                          print_move=print_move, *args, **kwargs)
     
-    def status(self, status="", offset=0, print_status=True, newline=False):
+    def status(self, status="", offset=0, print_status=True, newline=False, 
+               short=False):
         """
         Returns the status of the device.
         
@@ -620,16 +622,21 @@ class AeroBase(EpicsMotor):
         status : str
             Status string.
         """
-        status += "{0}{1}\n".format(" "*offset, self.desc)
-        status += "{0}PV: {1:>25}\n".format(" "*(offset+2), self.prefix)
-        status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2), 
-                                                 str(self.enabled))
-        status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2), 
-                                                 str(self.faulted))
-        status += "{0}Position: {1:>19}\n".format(" "*(offset+2), 
-                                                  np.round(self.wm(), 6))
-        status += "{0}Limits: {1:>21}\n".format(
-            " "*(offset+2), str((int(self.low_limit), int(self.high_limit))))
+        if short:
+            status += "\n{0}{1:<16}|{2:^16.3f}|{3:^16.3f}".format(
+                " "*offset, self.desc, self.position, self.dial.value)
+        else:
+            status += "{0}{1}\n".format(" "*offset, self.desc)
+            status += "{0}PV: {1:>25}\n".format(" "*(offset+2), self.prefix)
+            status += "{0}Enabled: {1:>20}\n".format(" "*(offset+2), 
+                                                     str(self.enabled))
+            status += "{0}Faulted: {1:>20}\n".format(" "*(offset+2), 
+                                                     str(self.faulted))
+            status += "{0}Position: {1:>19}\n".format(" "*(offset+2), 
+                                                      np.round(self.wm(), 6))
+            status += "{0}Limits: {1:>21}\n".format(
+                " "*(offset+2), str((int(self.low_limit), int(self.high_limit))))
+
         if newline:
             status += "\n"
         if print_status is True:

--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -382,7 +382,7 @@ class AeroBase(EpicsMotor):
             Status object for the move.
         """
         return self.mv(rel_position + self.position, wait=wait,
-                       ret_status=ret_status, print_move=print_status, *args,
+                       ret_status=ret_status, print_move=print_move, *args,
                        **kwargs)
 
     def check_status(self, position, *args, **kwargs):
@@ -644,7 +644,7 @@ class AeroBase(EpicsMotor):
         if newline:
             status += "\n"
         if print_status is True:
-            print(status)
+            logger.info(status)
         else:
             return status
 
@@ -668,8 +668,8 @@ class InterlockedAero(AeroBase):
     _pressure = FormattedComponent(PressureSwitch,
                                    "{self._prefix}:N2:{self._tower}")
     def __init__(self, prefix, *args, **kwargs):
-        self._tower = prefix.split(":")[-1]
-        self._prefix = ":".join(prefix.split(":")[:1])
+        self._tower = prefix.split(":")[-2]
+        self._prefix = ":".join(prefix.split(":")[:2])
         super().__init__(prefix, *args, **kwargs)
 
 

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -475,16 +475,16 @@ class EccBase(Device, PositionerBase):
             Status object for the move.
         """
         try:
-            return self.move(position, ret_status=ret_status, print_move=print_move,
-                             *args, **kwargs)
+            return self.move(position, ret_status=ret_status, 
+                             print_move=print_move, *args, **kwargs)
 
         # Catch all the common motor exceptions
         except LimitError:
-            logger.warning("Requested move '{0}' is outside the soft limits {1}."
-                           "".format(position, self.limits))
+            logger.warning("Requested move '{0}' is outside the soft limits "
+                           "{1}.".format(position, self.limits))
         except MotorDisabled:
-            logger.warning("Cannot move - motor is currently disabled. Try running"
-                           " 'motor.enable()'.")
+            logger.warning("Cannot move - motor is currently disabled. Try "
+                           "running 'motor.enable()'.")
         except MotorError:
             logger.warning("Cannot move - motor currently has an error. Try "
                            "running 'motor.clear()'.")

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -89,7 +89,7 @@ class EccBase(Device, PositionerBase):
     # commands
     motor_stop = Component(EpicsSignal, ":CMD:STOP")
     motor_reset = Component(EpicsSignal, ":CMD:RESET.PROC")
-    motor_enable = Component(EpicsSignal, ":CMD:EOT")
+    motor_enable = Component(EpicsSignal, ":CMD:ENABLE")
 
     def __init__(self, prefix, desc=None, *args, **kwargs):
         self.desc=desc

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -684,7 +684,7 @@ class EccBase(Device, PositionerBase):
         if newline:
             status += "\n"
         if print_status is True:
-            print(status)
+            logger.info(status)
         else:
             return status
 

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -6,8 +6,8 @@ Attocube devices
 ############
 # Standard #
 ############
-import logging
 import os
+import logging
 
 ###############
 # Third Party #
@@ -28,9 +28,10 @@ from pcdsdevices.epics.epicsmotor import EpicsMotor
 ##########
 # Module #
 ##########
+from .utils import get_logger
 from .exceptions import MotorDisabled, MotorError
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class EccController(Device):

--- a/hxrsnd/bragg.py
+++ b/hxrsnd/bragg.py
@@ -19,8 +19,9 @@ import numpy as np
 ##########
 # Module #
 ##########
+from .utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 # Globals
 

--- a/hxrsnd/bragg.py
+++ b/hxrsnd/bragg.py
@@ -56,12 +56,12 @@ def sind(A):
     Parameters
     ----------
     A : float
-    	Angle in degrees.
+        Angle in degrees.
 
     Returns
     -------
     x : float
-    	Sin of the angle.
+        Sin of the angle.
     """
     Arad = np.deg2rad(A)
     x = np.sin(Arad) 
@@ -74,12 +74,12 @@ def cosd(A):
     Parameters
     ----------
     A : float
-    	Angle in degrees.
+        Angle in degrees.
 
     Returns
     -------
     x : float
-    	Cos of the angle.
+        Cos of the angle.
     """
     Arad = np.deg2rad(A)
     x = np.cos(Arad) 
@@ -92,12 +92,12 @@ def tand(A):
     Parameters
     ----------
     A : float
-    	Angle in degrees.
+        Angle in degrees.
 
     Returns
     -------
     x : float
-    	Tan of the angle.
+        Tan of the angle.
     """
     Arad = np.deg2rad(A)
     x = np.tan(Arad) 
@@ -110,12 +110,12 @@ def asind(x):
     Parameters
     ----------
     x : float
-    	Value to calculate arcsin of.
+        Value to calculate arcsin of.
 
     Returns
     -------
     A : float
-    	Arcsin of the value in degrees.
+        Arcsin of the value in degrees.
     """
     A = np.arcsin(x)
     A = np.rad2deg(A) 
@@ -128,12 +128,12 @@ def acosd(x):
     Parameters
     ----------
     x : float
-    	Value to calculate arccos of.
+        Value to calculate arccos of.
 
     Returns
     -------
     A : float
-    	Arccos of the value in degrees.
+        Arccos of the value in degrees.
     """    
     A = np.arccos(x)
     A = np.rad2deg(A) 
@@ -146,12 +146,12 @@ def atand(x):
     Parameters
     ----------
     x : float
-    	Value to calculate arctan of.
+        Value to calculate arctan of.
 
     Returns
     -------
     A : float
-    	Arctan of the value in degrees.
+        Arctan of the value in degrees.
     """    
     A = np.arctan(x)
     A = np.rad2deg(A) 
@@ -190,12 +190,12 @@ def lam2E(l):
     Parameters
     ----------    
     l : float
-    	Photon wavelength in m
+        Photon wavelength in m
     
     Returns
     -------
     E : float
-    	Energy in eV
+        Energy in eV
     """
     E = 12398.4/(l*u['ang'])
     return E
@@ -207,14 +207,14 @@ def lam2f(l):
     Parameters
     ----------    
     l : float
-    	Photon wavelength in m
+        Photon wavelength in m
     
     Returns
     -------
     f : float
-    	Frequency in Hz
+        Frequency in Hz
     """
-    f = c['c']/l
+    f = 299792458/l
     return f    
 
 # Higher level functions

--- a/hxrsnd/bragg.py
+++ b/hxrsnd/bragg.py
@@ -327,21 +327,21 @@ def d_space(ID, hkl):
     d = invdsqr**-0.5
     return d
 
-def bragg_angle(ID="Si", hkl=(2,2,0), E=None):
+def bragg_angle(E=None, ID="Si", hkl=(2,2,0)):
     """
     Computes the Bragg angle (deg) of the specified material, reflection and
     photon energy.
 
     Parameters
     ----------
+    E : float, optional
+        Photon energy in eV or keV (default is LCLS value)
+
     ID : str, optional
         Chemical fomula : 'Si'
 
     hlk : tuple, optional
         The reflection : (2,2,0)
-
-    E : float, optional
-        Photon energy in eV or keV (default is LCLS value)
 
     Returns
     -------

--- a/hxrsnd/detectors.py
+++ b/hxrsnd/detectors.py
@@ -17,8 +17,9 @@ from pcdsdevices.epics.areadetector.detectors import DetectorBase
 ##########
 # Module #
 ##########
+from .utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class GigeCam(CamBase):

--- a/hxrsnd/diode.py
+++ b/hxrsnd/diode.py
@@ -22,10 +22,11 @@ from pcdsdevices.component import Component
 ##########
 # Module #
 ##########
+from .utils import get_logger
 from .aerotech import DiodeAero
 from .detectors import GigeDetector
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class DiodeBase(Device):

--- a/hxrsnd/exceptions.py
+++ b/hxrsnd/exceptions.py
@@ -8,17 +8,7 @@ Exceptions for the SnD system.
 ############
 import logging
 
-###############
-# Third Party #
-###############
-
-########
-# SLAC #
-########
-
-##########
-# Module #
-##########
+logger = logging.getLogger(__name__)
 
 # Exceptions
 

--- a/hxrsnd/exceptions.py
+++ b/hxrsnd/exceptions.py
@@ -22,21 +22,21 @@ import logging
 
 # Exceptions
 
-class SnDException(Exception):
+class SndException(Exception):
     """
     Base aerotech motor exceptions.
     """
     pass
 
 
-class MotorDisabled(SnDException):
+class MotorDisabled(SndException):
     """
     Exception raised when an action requiring the motor be enabled is requested.
     """
     pass
 
 
-class MotorFaulted(SnDException):
+class MotorFaulted(SndException):
     """
     Exception raised when an action requiring the motor not be faulted is 
     requested.
@@ -44,7 +44,7 @@ class MotorFaulted(SnDException):
     pass
 
 
-class MotorError(SnDException):
+class MotorError(SndException):
     """
     Exception raised when an action requiring the motor not have an error is 
     requested.
@@ -52,7 +52,7 @@ class MotorError(SnDException):
     pass
 
 
-class BadN2Pressure(SnDException):
+class BadN2Pressure(SndException):
     """
     Exception raised when an action requiring the N2 pressure be good is 
     requested with a bad pressure.

--- a/hxrsnd/exceptions.py
+++ b/hxrsnd/exceptions.py
@@ -38,13 +38,23 @@ class MotorDisabled(SnDException):
 
 class MotorFaulted(SnDException):
     """
-    Exception raised when an action requiring the motor not be faulted is requested.
+    Exception raised when an action requiring the motor not be faulted is 
+    requested.
     """
     pass
 
 
 class MotorError(SnDException):
     """
-    Exception raised when an action requiring the motor not have an error is requested.
+    Exception raised when an action requiring the motor not have an error is 
+    requested.
+    """
+    pass
+
+
+class BadN2Pressure(SnDException):
+    """
+    Exception raised when an action requiring the N2 pressure be good is 
+    requested with a bad pressure.
     """
     pass

--- a/hxrsnd/exceptions.py
+++ b/hxrsnd/exceptions.py
@@ -8,7 +8,12 @@ Exceptions for the SnD system.
 ############
 import logging
 
-logger = logging.getLogger(__name__)
+##########
+# Module #
+##########
+from .utils import get_logger
+
+logger = get_logger(__name__)
 
 # Exceptions
 

--- a/hxrsnd/plans.py
+++ b/hxrsnd/plans.py
@@ -19,9 +19,10 @@ from bluesky.plans      import subs_decorator
 ##########
 # Module #
 ##########
+from .utils import get_logger
 from .errors import UndefinedBounds
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 def block_run_control(msg):
     """

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -56,7 +56,8 @@ class PneuBase(Device):
         status : str
             Status string.
         """
-        status += "{0}{1}: {2}\n".format(" "*offset, self.desc, self.position)
+        status += "{0}{1:<16}|{2:^16}\n".format(" "*offset, self.desc+"", 
+                                                self.position)
         if newline:
             status += "\n"
         if print_status is True:
@@ -243,7 +244,6 @@ class SndPneumatics(Device):
         if self.desc is None:
             self.desc = self.name
 
-
     def status(self, status="", offset=0, print_status=True, newline=False):
         """
         Returns the status of the vacuum system.
@@ -267,7 +267,9 @@ class SndPneumatics(Device):
         status : str
             Status string.
         """
-        status += "{0}Vacuum\n{1}{2}\n".format(" "*offset, " "*offset, "-"*6)
+        status += "\n{0}Pneumatics".format(" "*offset)
+        status += "\n{1}{2}\n{3:^15}|{4:^15}\n{1}{2}".format(
+            " "*(offset+2), "-"*34, "Device", "State", " "*(offset+2), "-"*34)
         for valve in self._valves:
             status += valve.status(offset=offset+2, print_status=False)
         for pressure in self._pressure_switches:

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -20,7 +20,12 @@ from pcdsdevices.device import Device
 from pcdsdevices.component import Component
 from pcdsdevices.epics.signal import EpicsSignal, EpicsSignalRO
 
-logger = logging.getLogger(__name__)
+##########
+# Module #
+##########
+from .utils import get_logger
+
+logger = get_logger(__name__)
 
 class PneuBase(Device):
     """

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -66,7 +66,7 @@ class PneuBase(Device):
         if newline:
             status += "\n"
         if print_status is True:
-            print(status)
+            logger.info(status)
         else:
             return status
 
@@ -283,7 +283,7 @@ class SndPneumatics(Device):
         if newline:
             status += "\n"
         if print_status is True:
-            print(status)
+            logger.info(status)
         else:
             return status
 
@@ -311,7 +311,7 @@ class SndPneumatics(Device):
         status = ""
         for valve in self._valves:
             status += valve.status(print_status=False)
-        print(status)
+        logger.info(status)
 
     @property
     def pressures(self):
@@ -321,7 +321,7 @@ class SndPneumatics(Device):
         status = ""
         for pressure in self._pressure_switches:
             status += pressure.status(print_status=False)
-        print(status)
+        logger.info(status)
 
     def __repr__(self):
         """

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -268,8 +268,8 @@ class SndPneumatics(Device):
             Status string.
         """
         status += "\n{0}Pneumatics".format(" "*offset)
-        status += "\n{1}{2}\n{3:^15}|{4:^15}\n{1}{2}".format(
-            " "*(offset+2), "-"*34, "Device", "State", " "*(offset+2), "-"*34)
+        status += "\n{0}{1}\n{0}{2:^16}|{3:^16}\n{0}{4}\n".format(
+            " "*(offset+2), "-"*34, "Device", "State", "-"*34)
         for valve in self._valves:
             status += valve.status(offset=offset+2, print_status=False)
         for pressure in self._pressure_switches:

--- a/hxrsnd/rtd.py
+++ b/hxrsnd/rtd.py
@@ -20,8 +20,9 @@ from pcdsdevices.device import Device
 ##########
 # Module #
 ##########
+from .utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class RTDBase(Device):

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -29,8 +29,7 @@ from .bragg import bragg_angle, cosd, sind
 from .state import OphydMachine
 from .pneumatic import SndPneumatics
 from .tower import DelayTower, ChannelCutTower
-from .diode import (HamamatsuDiode, HamamatsuXMotionDiode,
-                                     HamamatsuXYMotionCamDiode)
+from .diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
 
 logger = logging.getLogger(__name__)
             
@@ -88,7 +87,7 @@ class SplitAndDelay(Device):
     t3 = Component(ChannelCutTower, ":T3", pos_inserted=None, 
                    pos_removed=0, desc="Tower 3")
 
-    # Vacuum
+    # Pneumatic Air Bearings
     ab = Component(SndPneumatics, "")
 
     # SnD and Delay line diodes
@@ -724,13 +723,14 @@ class SplitAndDelay(Device):
         """
         status =  "Split and Delay System Status\n"
         status += "-----------------------------\n"
-        status += "  Energy 1: {:>8.3f}\n".format(self.energy1)
-        status += "  Energy 2: {:>8.3f}\n".format(self.energy2)
-        status += "  Delay:    {:>8.3f}\n\n".format(self.delay)
+        status += "  Energy 1: {:>10.3f}\n".format(self.energy1)
+        status += "  Energy 2: {:>10.3f}\n".format(self.energy2)
+        status += "  Delay:    {:>10.3f}\n".format(self.delay)
         status = self.t1.status(status, 0, print_status=False, newline=True)
         status = self.t2.status(status, 0, print_status=False, newline=True)
         status = self.t3.status(status, 0, print_status=False, newline=True)
-        status = self.t4.status(status, 0, print_status=False, newline=False)
+        status = self.t4.status(status, 0, print_status=False, newline=True)
+        status = self.ab.status(status, 0, print_status=False, newline=False)
 
         if print_status:
             print(status)

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -19,7 +19,7 @@ from ophyd.utils.epics_pvs import raise_if_disconnected
 # SLAC #
 ########
 from pcdsdevices.device import Device
-from pcdsdevices.component import Component, FormattedComponent
+from pcdsdevices.component import Component
 
 ##########
 # Module #
@@ -475,7 +475,7 @@ class SplitAndDelay(Device):
             
         # Move the delay stages
         if delay is not None and length is not None:
-            status += [tower.set_delay(lenth, wait=False, check_status=False) 
+            status += [tower.set_delay(length, wait=False, check_status=False) 
                        for tower in self.delay_towers]
 
         return status        

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -347,43 +347,7 @@ class SplitAndDelay(Device):
         if response.lower() != "y":
             return True
         else:
-            return False    
-        
-    def _apply_tower_move_method(self, position, towers, move_method, 
-                                 wait=False, *args, **kwargs):
-        """
-        Runs the inputted aggregate move method on each tower and then 
-        optionally waits for the move to complete. A move method is defined as
-        being a method that returns a status object, or list of status objects.
-
-        Any additional arguments or keyword arguments will be passed to 
-        move_method.
-
-        Parmeters
-        ---------
-        position : float
-            Position to pass to the move method.
-
-        towers : list
-            List of towers to set the energy for.
-
-        move_method : str
-            Method of each tower to run.
-
-        wait : bool, optional
-            Wait for each tower to complete the motion.
-        """
-        # Check that there are no issues moving any of the tower motors        
-        status = [getattr(t, move_method)(position, *args, **kwargs) 
-                  for t in towers]
-
-        # Wait for the motions to finish
-        if wait:
-            for s in flatten(status):
-                logger.info("Waiting for {} to finish move ...".format(
-                    s.device.name))
-                status_wait(s)
-        return status
+            return False            
 
     def _check_towers_and_diagnostics(self, E1=None, E2=None, delay=None):
         """

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -92,13 +92,13 @@ class SplitAndDelay(Device):
     ab = Component(SndPneumatics, "")
 
     # SnD and Delay line diodes
-    di = Component(HamamatsuXYMotionCamDiode, ":DIA:DI")
+    di = Component(HamamatsuXMotionDiode, ":DIA:DI")
     dd = Component(HamamatsuXYMotionCamDiode, ":DIA:DD")
-    do = Component(HamamatsuXYMotionCamDiode, ":DIA:DO")
+    do = Component(HamamatsuXMotionDiode, ":DIA:DO")
 
     # Channel Cut Diodes
     dci = Component(HamamatsuXMotionDiode, ":DIA:DCI")
-    dcc = Component(HamamatsuXMotionDiode, ":DIA:DCC")
+    dcc = Component(HamamatsuXYMotionCamDiode, ":DIA:DCC")
     dco = Component(HamamatsuXMotionDiode, ":DIA:DCO")
     
     # Constants

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -724,9 +724,9 @@ class SplitAndDelay(Device):
         """
         status =  "Split and Delay System Status\n"
         status += "-----------------------------\n"
-        status += "  Energy 1: {>8.3f}\n".format(self.energy1)
-        status += "  Energy 2: {>8.3f}\n".format(self.energy2)
-        status += "  Delay:    {>8.3f}\n\n".format(self.delay)
+        status += "  Energy 1: {:>8.3f}\n".format(self.energy1)
+        status += "  Energy 2: {:>8.3f}\n".format(self.energy2)
+        status += "  Delay:    {:>8.3f}\n\n".format(self.delay)
         status = self.t1.status(status, 0, print_status=False, newline=True)
         status = self.t2.status(status, 0, print_status=False, newline=True)
         status = self.t3.status(status, 0, print_status=False, newline=True)

--- a/hxrsnd/state.py
+++ b/hxrsnd/state.py
@@ -13,8 +13,10 @@ from super_state_machine.extras  import PropertyMachine
 ##########
 # Module #
 ##########
+from .utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
+
 
 class MachineMeta(ComponentMeta):
     """

--- a/hxrsnd/tests/test_aerotech.py
+++ b/hxrsnd/tests/test_aerotech.py
@@ -24,14 +24,15 @@ from pcdsdevices.sim.pv import  using_fake_epics_pv
 ##########
 from .conftest import get_classes_in_module
 from hxrsnd import aerotech
+from hxrsnd.utils import get_logger
 from hxrsnd.aerotech import (AeroBase, MotorDisabled, MotorFaulted)
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__, log_file=False)
 
 @using_fake_epics_pv
 @pytest.mark.parametrize("dev", get_classes_in_module(aerotech, Device))
 def test_aerotech_devices_instantiate_and_run_ophyd_functions(dev):
-    motor = dev("TEST")
+    motor = dev("TEST:SND:T1")
     assert(isinstance(motor.read(), OrderedDict))
     assert(isinstance(motor.describe(), OrderedDict))
     assert(isinstance(motor.describe_configuration(), OrderedDict))

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -214,7 +214,7 @@ class TowerBase(Device):
             Length to set the delay stage to. (Doesnt apply for cc towers)
 
         no_raise : bool, optional
-            Do not re-raise the attribute error for delay parameters
+            Do not re-raise the attribute error for delay parameters.
         """
         # Create the list of motors and positions we will iterate through
         motors = []
@@ -225,7 +225,7 @@ class TowerBase(Device):
             motors += self._energy_motors
             theta = bragg_angle(energy)
             positions += self._get_move_positions(theta)
-
+            
         # Get the delay parameters
         try:
             if length is not None:
@@ -329,7 +329,7 @@ class TowerBase(Device):
         if newline:
             status += "\n"
         if print_status:
-            print(status)
+            logger.info(status)
         else:
             return status
 

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -293,9 +293,8 @@ class TowerBase(Device):
         """
         status += "{0}{1}:\n{2}{3}\n".format(" "*offset, self.desc,
                                              " "*offset, "-"*(len(self.desc)+1))
-        status_list = self._apply_all("status", (AeroBase, EccBase),
-                                      method_kwargs={"offset":offset+2,
-                                                     "print_status":False})
+        status_list = self._apply_all("status", (AeroBase, EccBase), 
+                                      offset=offset+2, print_status=False)
         status += "".join(status_list)
         if newline:
             status += "\n"
@@ -398,7 +397,7 @@ class DelayTower(TowerBase):
         self._chi1 = chi1 or "CHI1"
         self._chi2 = chi2 or "CHI2"
         self._dh = dh or "DH"
-        self._prefix = ":".join(prefix.split(":")[:1])
+        self._prefix = ":".join(prefix.split(":")[:2])
         super().__init__(prefix, *args, **kwargs)
         self._energy_motors = [self.tth, self.th1, self.th2]
 

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -22,9 +22,9 @@ from pcdsdevices.component import Component, FormattedComponent
 from .rtd import OmegaRTD
 from .utils import flatten
 from .state import OphydMachine
-from .pneumatic import PressureSwitch
 from .bragg import bragg_angle, bragg_energy
-from .aerotech import AeroBase, RotationAero, LinearAero
+from .aerotech import (AeroBase, RotationAero, InterRotationAero,
+                       LinearAero, InterLinearAero)
 from .attocube import EccBase, TranslationEcc, GoniometerEcc, DiodeEcc
 from .diode import (HamamatsuDiode, HamamatsuXMotionDiode,
                                      HamamatsuXYMotionCamDiode)
@@ -182,30 +182,63 @@ class TowerBase(Device):
                                                    **method_kwargs))
         return ret
 
-    def check_status(self, energy=True, delay=False):
+    def _get_move_positions(self, E):
+        """
+        Returns a list of positions that the energy motors should move to based
+        on the inputted theta. Base implementation just returns a list of theta
+        with length len(self._energy_motors).
+
+        Parameters
+        ----------
+        E : float
+            Energy to compute the motor move positions for.
+
+        Returns
+        -------
+        positions : list
+            List of positions each of the energy motors need to move to.
+        """
+        return [bragg_angle(E)] * len(self._energy_motors)
+
+    def check_status(self, energy=None, length=None, no_raise=False):
         """
         Checks to make sure that all the energy motors are not in a bad state. 
         Will include the delay motor if the delay argument is True.
 
         Parameters
         ----------
-        energy : bool, optional
-            Check the energy motors.
+        energy : float or None, optional
+            Energy to set the tower to.
 
-        delay : bool, optional
-            Check the delay motor.
+        length : float or None, optional
+            Length to set the delay stage to. (Doesnt apply for cc towers)
+
+        no_raise : bool, optional
+            Do not re-raise the attribute error for delay parameters
         """
-        # Create the list of motors we will iterate through
+        # Create the list of motors and positions we will iterate through
         motors = []
-        if energy:
+        positions = []
+
+        # Get all the energy parameters
+        if energy is not None:
             motors += self._energy_motors
-        if delay:
-            motors += [self.L]
+            theta = bragg_angle(energy)
+            positions += self._get_move_positions(theta)
+
+        # Get the delay parameters
+        try:
+            if length is not None:
+                motors += [self.L]
+                positions += length
+        except AttributeError:
+            if not no_raise:
+                raise
         
         # Check that we can move all the motors
-        for motor in motors:
+        for motor, position in zip(motors, positions):
             try:
-                motor.check_status()
+                motor.check_status(position)
             except Exception as e:
                 err = "Motor {0} got an exception: {1}".format(motor.name, e)
                 logger.error(err)
@@ -290,50 +323,50 @@ class DelayTower(TowerBase):
     
     Components
     ----------
-    tth : RotationAero
-        Rotation axis of the entire delay arm
+    tth : RotationAeroInterlocked
+        Rotation axis of the entire delay arm.
 
     th1 : RotationAero
-        Rotation axis of the static crystal
+        Rotation axis of the static crystal.
 
     th2 : RotationAero
-        Rotation axis of the delay crystal
+        Rotation axis of the delay crystal.
 
     x : LinearAero
-        Linear stage for insertion/bypass of the tower
+        Linear stage for insertion/bypass of the tower.
 
     L : LinearAero
-        Linear stage for the delay crystal
+        Linear stage for the delay crystal.
 
     y1 : TranslationEcc
-        Y translation for the static crystal
+        Y translation for the static crystal.
 
     y2 : TranslationEcc
-        Y translation for the delay crystal
+        Y translation for the delay crystal.
 
     chi1 : GoniometerEcc
-        Goniometer on static crystal
+        Goniometer on static crystal.
 
     chi2 : GoniometerEcc
-        Goniometer on delay crystal
+        Goniometer on delay crystal.
 
     dh : DiodeEcc
-        Diode insertion motor
+        Diode insertion motor.
 
     diode : HamamatsuDiode
-        Diode between the static and delay crystals
+        Diode between the static and delay crystals.
 
     temp : OmegaRTD
-        RTD temperature sensor for the nitrogen.    
+        RTD temperature sensor for the nitrogen.
     """
     # Rotation stages
-    tth = Component(RotationAero, ":TTH", desc="Two Theta")
+    tth = Component(InterRotationAero, ":TTH", desc="Two Theta")
     th1 = Component(RotationAero, ":TH1", desc="Theta 1")
     th2 = Component(RotationAero, ":TH2", desc="Theta 2")
 
     # Linear stages
-    x = Component(LinearAero, ":X", desc="Tower X")
-    L = Component(LinearAero, ":L", desc="Delay Stage")
+    x = Component(InterLinearAero, ":X", desc="Tower X")
+    L = Component(InterLinearAero, ":L", desc="Delay Stage")
 
     # Y Crystal motion
     y1 = FormattedComponent(TranslationEcc, "{self._prefix}:ECC:{self._y1}",
@@ -350,10 +383,6 @@ class DelayTower(TowerBase):
     # Diode motion
     dh = FormattedComponent(DiodeEcc, "{self._prefix}:ECC:{self._dh}",
                             desc="Diode Motor")
-
-    # To do the internel pressure check
-    _pressure = FormattedComponent(PressureSwitch, 
-                                   "{self._prefix}:N2:{self._tower}")
     
     # # Diode
     # diode = Component(HamamatsuDiode, ":DIODE", desc="Tower Diode")
@@ -369,14 +398,9 @@ class DelayTower(TowerBase):
         self._chi1 = chi1 or "CHI1"
         self._chi2 = chi2 or "CHI2"
         self._dh = dh or "DH"
-        self._tower = prefix.split(":")[-1]
         self._prefix = ":".join(prefix.split(":")[:1])
         super().__init__(prefix, *args, **kwargs)
-        self._energy_motors = [self.tth, self.th1, self.th2]        
-
-        # Interlock tth, x and L
-        for motor in [self.tth, self.x, self.L]:
-            motor.additional_status_check = self._check_pressure
+        self._energy_motors = [self.tth, self.th1, self.th2]
 
     @property
     def position(self):
@@ -389,6 +413,34 @@ class DelayTower(TowerBase):
             Position of the arm in degrees.
         """
         return self.tth.position
+
+    def _get_move_positions(self, E):
+        """
+        Returns the list of positions that each of the energy motors need to
+        move to based on the inputted theta. tth moves to 2*theta while all
+        the other motors move to theta.
+
+        Parameters
+        ----------
+        E : float
+            Energy to compute the motor move positions for.
+
+        Returns
+        -------
+        positions : list
+            List of positions each of the energy motors need to move to.
+        """
+        # Convert to theta
+        theta = bragg_angle(E)
+
+        # Get the positions
+        positions = []
+        for motor in self._energy_motors:
+            if motor is self.tth:
+                positions.append(2*theta)
+            else:
+                positions.append(theta)
+        return positions
 
     def set_energy(self, E, wait=False, check_status=True):
         """
@@ -408,19 +460,15 @@ class DelayTower(TowerBase):
         """
         # Check to make sure the motors are in a valid state to move
         if check_status:
-            self.check_status()
+            self.check_status(energy=E)
         logger.debug("\nMoving {tth} to {tth_theta} \nMoving {th1} and {th2} to"
                      " {th_theta}.".format(tth=self.tth.name, th1=self.th1.name, 
                                            th2=self.th2.name, tth_theta=2*theta,
                                            th_theta=theta))
-
-        # Convert to theta1
-        theta = bragg_angle(E=E)
-
-        # Do the move
-        move_pos = [2*theta, theta, theta]
+        
+        # Perform the move
         status = [motor.move(pos, wait=False, check_status=False) for
-                  move, pos in zip(motors, move_pos)]
+                  move, pos in zip(motors, self._get_move_positions(E))]
 
         # Wait for the motions to finish
         if wait:
@@ -431,7 +479,7 @@ class DelayTower(TowerBase):
                 
         return status
 
-    def set_length(self, position, wait=True, *args, **kwargs):
+    def set_length(self, position, wait=False, *args, **kwargs):
         """
         Sets the position of the linear delay stage in mm.
 
@@ -448,7 +496,7 @@ class DelayTower(TowerBase):
         status : MoveStatus
             Status object of the move.
         """
-        return self.L.mv(position, wait=wait, *args, **kwargs)
+        return self.L.move(position, wait=wait, *args, **kwargs)
 
     @property
     def length(self):
@@ -472,7 +520,7 @@ class DelayTower(TowerBase):
         position : float
             Position to move the delay motor to.
         """
-        status = self.set_length(position)
+        status = self.L.mv(position)
 
     @property
     def theta(self):
@@ -485,19 +533,6 @@ class DelayTower(TowerBase):
             Current position of the tower.
         """
         return self.position/2    
-
-    def _check_pressure(self):
-        """
-        Checks to make sure the tower N2 pressure is good and raises an
-        exception if not.
-        
-        Raises
-        ------
-        BadN2Pressure
-            Raised if the pressure of the N2 is bad for this tower.
-        """
-        if self._pressure.bad:
-            raise BadN2Pressure("Pressure in {0} is bad.".format(self._tower))
         
 
 class ChannelCutTower(TowerBase):
@@ -550,15 +585,16 @@ class ChannelCutTower(TowerBase):
         check_status : bool, optional
             Check if the motors are in a valid state to move.
         """
-        # Check to make sure the motors are in a valid state to move
-        if check_status:
-            self.check_status()
-        logger.debug("\nMoving {th} to {theta}".format(
-            th=self.th.name, theta=theta))
-            
         # Convert to theta
         theta = bragg_angle(E=E)
+        
+        # Check to make sure the motors are in a valid state to move
+        if check_status:
+            self.check_status(E)
+        logger.debug("\nMoving {th} to {theta}".format(
+            th=self.th.name, theta=theta))
 
+        # Perform the move
         status = self.th.move(theta, wait=wait)
         return status
 

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -268,7 +268,8 @@ class TowerBase(Device):
         """
         self._apply_all("clear", AeroBase, print_set=False)
 
-    def status(self, status="", offset=0, print_status=True, newline=False):
+    def status(self, status="", offset=0, print_status=True, newline=False, 
+               short=True):
         """
         Returns the status of the tower.
         
@@ -291,14 +292,42 @@ class TowerBase(Device):
         status : str
             Status string.
         """
-        status += "{0}{1}:\n{2}{3}\n".format(" "*offset, self.desc,
-                                             " "*offset, "-"*(len(self.desc)+1))
-        status_list = self._apply_all("status", (AeroBase, EccBase), 
-                                      offset=offset+2, print_status=False)
-        status += "".join(status_list)
+        if short:
+            # Header
+            status += "\n{0}{1}\n{2}{3}".format(
+                " "*offset, self.desc, " "*(offset+2), "-"*50)
+
+            # Aerotech body
+            status_list_aero = self._apply_all(
+                "status", AeroBase, offset=offset+2, print_status=False, 
+                short=True)
+            if status_list_aero:
+                # Aerotech header
+                status += "\n{0}{1:<16}|{2:^16}|{3:^16}\n{4}{5}".format(
+                    " "*(offset+2), "Motor", "Position", "Dial", " "*(offset+2), 
+                    "-"*50)
+                status += "".join(status_list_aero)
+
+            # Attocube body
+            status_list_atto = self._apply_all(
+                "status", EccBase, offset=offset+2, print_status=False, 
+                short=True)
+            if status_list_atto:
+                # Attocube Header
+                status += "\n{0}{1}\n{2}{3:<16}|{4:^16}|{5:^16}\n{6}{7}".format(
+                    " "*(offset+2), "-"*50, " "*(offset+2), "Motor", "Position",
+                    "Reference", " "*(offset+2), "-"*50)
+                status += "".join(status_list_atto)
+
+        else:
+            status += "{0}{1}:\n{2}{3}\n".format(
+                " "*offset, self.desc, " "*offset, "-"*(len(self.desc)+1))
+            status_list = self._apply_all("status", (AeroBase, EccBase), 
+                                          offset=offset+2, print_status=False)
+            status += "".join(status_list)
+
         if newline:
             status += "\n"
-
         if print_status:
             print(status)
         else:

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -22,13 +22,14 @@ from pcdsdevices.component import Component, FormattedComponent
 # Module #
 ##########
 from .rtd import OmegaRTD
+from .utils import get_logger
 from .diode import HamamatsuDiode
 from .bragg import bragg_angle, bragg_energy
 from .attocube import EccBase, TranslationEcc, GoniometerEcc, DiodeEcc
 from .aerotech import (AeroBase, RotationAero, InterRotationAero,
                        LinearAero, InterLinearAero)
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 class TowerBase(Device):
     """
@@ -61,7 +62,7 @@ class TowerBase(Device):
         E : float
             Energy of the delay line.
         """
-        return bragg_energy(self.theta)
+        return np.round(bragg_energy(self.theta), 3)
 
     @energy.setter
     def energy(self, E):
@@ -303,7 +304,7 @@ class TowerBase(Device):
             if status_list_aero:
                 # Aerotech header
                 status += "\n{0}{1:<16}|{2:^16}|{3:^16}\n{4}{5}".format(
-                    " "*(offset+2), "Motor", "Position", "Dial", " "*(offset+2), 
+                    " "*(offset+2), "Motor", "Position", "Dial", " "*(offset+2),
                     "-"*50)
                 status += "".join(status_list_aero)
 

--- a/hxrsnd/utils.py
+++ b/hxrsnd/utils.py
@@ -13,7 +13,32 @@ def get_logger(name, stream_level=logging.INFO, log_file=True,
                log_dir=Path("."), max_bytes=10*1024*1024):
     """
     Returns a properly configured logger that has a stream handler and a file
-    handler.
+    handler. This was made so that immediately setting up both a stream and
+    file handler is as easy as just calling this function and forgetting about
+    the details.
+
+    Parameters
+    ----------
+    name : str
+        Name for the logger.
+
+    stream_level : logging.level, optional
+        Logging level for what prints to the console.
+
+    log_file : bool, optional
+        Save to a log file.
+
+    log_dir : Path, optional
+        Path to where the log file should be saved.
+        
+    max_bytes : int, optional
+        Size of the log file in bytes.
+
+    Returns
+    -------
+    logger : logging.logger
+        Properly configured logger that has a stream and optionally a file
+        handler.
     """
     logger = logging.getLogger(name)
     logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Overview
-------------
PR to try and a couple more items on Diling's controls list. The following issues are addressed:
- Pressure checks before motions of `tth`, `x` and `L` motors.
   - New aerotech classes were made - `InterLinearAero` and `InterRotationAero` that have an extra component for the pressure switch and check in the `check_status` method.
- Energy and delay combined motion
  - Redid the energy and delay setting routine. There is now one pipeline that handles setting all the energies and delay with aliases that pass different arguments.
- Nicer handling of failures
   - At the motor level, whenever `mv` or `mvr` are used, they will catch motor errors and display them nicely. This still needs to be implemented at the higher level classes.
- `status()` prints are greatly reduced
  - There is a new `short` argument that can be passed to `status` that will output shortened statuses.
- Logging is now done in a more sensible way, with a streamhandler and file handler.
  - Console outputs at the info level, while everything is saved at the debug level.