### PR TITLE
ENH: Adding daq scans, fixed slow tab completion, optional diagnostic macro moves

### DIFF
--- a/bin/run_snd
+++ b/bin/run_snd
@@ -6,12 +6,20 @@ unset PYTHONPATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/reg/common/package/epicsca/3.14.12/lib/rhel6-x86_64
 export PATH=/reg/g/pcds/pyps/conda/rhel6/bin:$PATH
 
-# Activate the conda environment
+# These have to be included otherwise there you get the following error then a
+# seg fault:
+#       QXcbConnection: Could not connect to display
+# This needs to point to the conda env being used
+export QT_XKB_CONFIG_ROOT='/reg/g/pcds/pyps/conda/rhel6/envs/snd_opr/lib'
+# This ensures the terminal doesn't totally screw up
+export QT_QPA_PLATFORM='offscreen'
+
+# Activate the snd_opr conda environment
 source activate snd_opr
 
-# Get the current directory
+# Get the directory of this script resolving soft links
 FILE=`readlink -f $0`
 SCRIPTPATH=`dirname $FILE`
 
-# Start the ipython shell
+# Start the ipython shell using the snd environment
 ipython -i $SCRIPTPATH/run_snd.py

--- a/bin/run_snd.py
+++ b/bin/run_snd.py
@@ -2,10 +2,23 @@
 # Standard #
 ############
 import logging
+from imp import reload
+
+###############
+# Third Party #
+###############
+from bluesky import RunEngine
+from bluesky.plans import run_wrapper
+
+########
+# SLAC #
+########
+from pcdsdevices.daq import make_daq_run_engine
 
 ##########
 # Module #
 ##########
+from hxrsnd.plans import daq_scan
 from hxrsnd.utils import get_logger
 from hxrsnd.pneumatic import SndPneumatics
 from hxrsnd.sndsystem import SplitAndDelay
@@ -13,41 +26,41 @@ from hxrsnd.tower import DelayTower, ChannelCutTower
 from hxrsnd.bragg import bragg_angle, bragg_energy, sind, cosd
 from hxrsnd.diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
 
-
 # Logging
 logger = get_logger(__name__)
 
 # Instantiate the system
 pv_base = "XCS:SND"
 
-try:
-    # The whole system
-    snd = SplitAndDelay(pv_base)
-    
-    # Towers
-    t1 = DelayTower(pv_base + ":T1", y1="A:ACT0", y2="A:ACT1", chi1="A:ACT2",
-                    chi2="B:ACT0", dh="B:ACT1", pos_inserted=21.1,
-                    pos_removed=0, desc="Tower 1")
-    t2 = ChannelCutTower(pv_base + ":T2", pos_inserted=None, pos_removed=0, 
-                         desc="Tower 2")
-    t3 = ChannelCutTower(pv_base + ":T3", pos_inserted=None, pos_removed=0, 
-                         desc="Tower 3")
-    t4 = DelayTower(pv_base + ":T4", y1="C:ACT0", y2="C:ACT1", chi1="C:ACT2",
-                    chi2="D:ACT0", dh="D:ACT1", pos_inserted=21.1,
-                    pos_removed=0, desc="Tower 4")
+# The whole system
+snd = SplitAndDelay(pv_base)
 
-    # Vacuum
-    ab = SndPneumatics(pv_base)
+# Towers
+t1 = DelayTower(pv_base + ":T1", y1="A:ACT0", y2="A:ACT1", chi1="A:ACT2",
+                chi2="B:ACT0", dh="B:ACT1", pos_inserted=21.1,
+                pos_removed=0, desc="Tower 1")
+t2 = ChannelCutTower(pv_base + ":T2", pos_inserted=None, pos_removed=0, 
+                     desc="Tower 2")
+t3 = ChannelCutTower(pv_base + ":T3", pos_inserted=None, pos_removed=0, 
+                     desc="Tower 3")
+t4 = DelayTower(pv_base + ":T4", y1="C:ACT0", y2="C:ACT1", chi1="C:ACT2",
+                chi2="D:ACT0", dh="D:ACT1", pos_inserted=21.1,
+                pos_removed=0, desc="Tower 4")
 
-    # Diagnostics
-    di = HamamatsuXMotionDiode(pv_base + ":DIA:DI")
-    dd = HamamatsuXYMotionCamDiode(pv_base + ":DIA:DD")
-    do = HamamatsuXMotionDiode(pv_base + ":DIA:DO")
-    dci = HamamatsuXMotionDiode(pv_base + ":DIA:DCI")
-    dcc = HamamatsuXYMotionCamDiode(pv_base + ":DIA:DCC")
-    dco = HamamatsuXMotionDiode(pv_base + ":DIA:DCO")
-except TimeoutError:
-    logger.error("Timeout on getting PVs.")
+# Vacuum
+ab = SndPneumatics(pv_base)
+
+# Diagnostics
+di = HamamatsuXMotionDiode(pv_base + ":DIA:DI")
+dd = HamamatsuXYMotionCamDiode(pv_base + ":DIA:DD")
+do = HamamatsuXMotionDiode(pv_base + ":DIA:DO")
+dci = HamamatsuXMotionDiode(pv_base + ":DIA:DCI")
+dcc = HamamatsuXYMotionCamDiode(pv_base + ":DIA:DCC")
+dco = HamamatsuXMotionDiode(pv_base + ":DIA:DCO")
+
+# Create a RunEngine
+RE = RunEngine({})
+RE_daq = make_daq_run_engine(snd.daq)
 
 # These are the calculations provided by Yanwen. They can be a useful sanity
 # check if things are being weird.

--- a/bin/run_snd.py
+++ b/bin/run_snd.py
@@ -18,7 +18,7 @@ from pcdsdevices.daq import make_daq_run_engine
 ##########
 # Module #
 ##########
-from hxrsnd.plans import daq_scan
+from hxrsnd.plans import linear_scan
 from hxrsnd.utils import get_logger
 from hxrsnd.pneumatic import SndPneumatics
 from hxrsnd.sndsystem import SplitAndDelay
@@ -28,6 +28,7 @@ from hxrsnd.diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
 
 # Logging
 logger = get_logger(__name__)
+get_logger("pcdsdevices")
 
 # Instantiate the system
 pv_base = "XCS:SND"

--- a/docs/source/running_the_daq.rst
+++ b/docs/source/running_the_daq.rst
@@ -1,0 +1,69 @@
+=================
+Running DAQ Scans
+=================
+Scans can be run using any of of the HXRSnD motors, including the virtual,
+motors using the DAQ. To perform the scans, the ``bluesky`` module is used
+meaning scans must be defined as plans that return messages to the ``bluesky``
+run engine, indicating the next step in the scan. Once defined, the plans are
+passed to the DAQ-configured ``RunEngine`` which will correctly run the DAQ with
+the scan.
+
+Defining the Scans
+==================
+
+Scans are defined in the ``hxrsnd.plans`` and are imported into the the main
+``ipython`` shell for HXRSnD. Using ``linear_scan`` as an example, simply
+define the scan as follows: ::
+
+    plan = linear_scan(snd.E2, 9000, 10000, 5, return_to_start=False)
+
+The variable ``plan`` now contains the sequence of steps that will be carried
+out during the scan.
+
+
+Configuring the DAQ
+===================
+
+Before any scans can be made, the DAQ must be configured both using normal DAQ
+EDM screens, and the python DAQ object.
+
+Overview
+--------
+
+Below is a quick list of what must be done to ensure the scan can work properly:
+
+- Restart the DAQ and ensure it is opened properly.
+- Select the proper configuration type and select all desired devices.
+- Configure the DAQ from python using the following command: ::
+
+    snd.daq.configure()
+
+Below is a list of the basic arguments that can be passed to change the behavior
+of the scan: ::
+    
+- To change the number of events taken at each step in the scan, pass the keyword argument ``events`` to the configure method. For example, the following will set the DAQ to take 1000 events at each step: ::
+
+    snd.daq.configure(events=1000)
+
+- To add a python value to be recorded in the DAQ, pass the keyword argument ``controls`` along with a ``dict`` that has a mapping from name to ``obj``. For example, the following will create DAQ source named "E2" which will contain the channel cut energy: ::
+
+    snd.daq.configure(controls={"E2" : snd.E2})
+
+- To record data, pass the keyword argument ``record`` along with ``True``. For example, to record the data for this run: ::
+
+    snd.daq.configure(record=True)
+
+
+Running the Scan
+================
+
+Once the scan has been instantiated and the DAQ has been configured both in the
+EDM screen and python, the scan can simply be passed into the run engine for
+execution: ::
+
+  RE_daq(plan)
+
+This should cause the daq to begin taking events at every scan step.
+
+**Note:** Once a plan has been run, it must be redeclared to be run again since
+the contents have been consumed.

--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -13,6 +13,7 @@ import os
 # Third Party #
 ###############
 import numpy as np
+from ophyd import Component, FormattedComponent
 from ophyd.utils import LimitError
 from ophyd.status import wait as status_wait
 
@@ -20,7 +21,6 @@ from ophyd.status import wait as status_wait
 # SLAC #
 ########
 from pcdsdevices.epics.epicsmotor import EpicsMotor
-from pcdsdevices.component import Component, FormattedComponent
 from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO, FakeSignal)
 
 ##########

--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -76,7 +76,7 @@ class AeroBase(EpicsMotor):
     axis_fault = Component(EpicsSignalRO, ":AXIS_FAULT")
     clear_error = Component(EpicsSignal, ":CLEAR")
     config = Component(EpicsSignal, ":CONFIG")
-    zero_all_proc = Component(EpicsSignal, ".ZERO_P.PROC")
+    zero_all_proc = Component(EpicsSignal, ":ZERO_P.PROC")
     home_forward = Component(EpicsSignal, ".HOMF")
     home_reverse = Component(EpicsSignal, ".HOMR")
     dial = Component(EpicsSignalRO, ".DRBV")

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -14,6 +14,7 @@ import logging
 ###############
 import numpy as np
 from ophyd import PositionerBase
+from ophyd import Component, FormattedComponent
 from ophyd.utils import LimitError
 from ophyd.status import wait as status_wait
 

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -78,7 +78,7 @@ class EccBase(Device, PositionerBase):
     motor_frequency = Component(EpicsSignal, ":CMD:FREQ")
 
     # motor status
-    motor_connected = Component(EpicsSignalRO, ":ST_CONNECTED")
+    motor_connected = Component(EpicsSignalRO, ":ST_CONNECT")
     motor_enabled = Component(EpicsSignalRO, ":ST_ENABLED")
     motor_referenced = Component(EpicsSignalRO, ":ST_REFVAL")
     motor_error = Component(EpicsSignalRO, ":ST_ERROR")

--- a/hxrsnd/diode.py
+++ b/hxrsnd/diode.py
@@ -56,5 +56,5 @@ class HamamatsuXYMotionCamDiode(HamamatsuXMotionDiode):
     Class for the Hamamatsu diode but with X and Y motors
     """
     y = Component(DiodeAero, ":Y")
-    cam = Component(GigeDetector, ":CAM")
+    # cam = Component(GigeDetector, ":CAM")
     

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -12,12 +12,12 @@ import logging
 # Third Party #
 ###############
 import numpy as np
+from ophyd import Component
 
 ########
 # SLAC #
 ########
 from pcdsdevices.device import Device
-from pcdsdevices.component import Component
 from pcdsdevices.epics.signal import EpicsSignal, EpicsSignalRO
 
 ##########

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -10,13 +10,13 @@ import logging
 # Third Party #
 ###############
 import numpy as np
+from ophyd import Component, FormattedComponent
 from ophyd.status import wait as status_wait
 
 ########
 # SLAC #
 ########
 from pcdsdevices.device import Device
-from pcdsdevices.component import Component, FormattedComponent
 
 ##########
 # Module #
@@ -69,8 +69,7 @@ class TowerBase(Device):
         E : float
             Energy of the delay line.
         """
-        # This is awful but please forgive me, np.round doesnt work as expected
-        return float("{:.3f}".format(bragg_energy(self.theta)))
+        return int(np.round(bragg_energy(self.theta)))
 
     @energy.setter
     def energy(self, E):

--- a/hxrsnd/utils.py
+++ b/hxrsnd/utils.py
@@ -41,7 +41,7 @@ def absolute_submodule_path(submodule, cur_dir=inspect.stack()[0][1]):
 LOG_DIR = absolute_submodule_path("HXRSnD/logs")
 
 def get_logger(name, stream_level=logging.INFO, log_file=True, 
-               log_dir=Path("."), max_bytes=10*1024*1024):
+               log_dir=Path(LOG_DIR), max_bytes=10*1024*1024):
     """
     Returns a properly configured logger that has a stream handler and a file
     handler. This was made so that immediately setting up both a stream and


### PR DESCRIPTION
Overview
=======
This PR adds the ability to scan using the DAQ by introducing a basic `linear_scan` plan and a runengine that is preconfigured to interface with the DAQ. There is also a document on how to properly run scans with the DAQ. Tab completion is now much faster since all objects are no longer instantiated lazily. When a macro move is made, you can now specify whether you want to move the diagnostic motors as well. Additional `exports` are included in the launcher script that should make it usable from `xcs_daq` and beyond.