### PR TITLE
FIX: Allowing the scans to be used with all motors.

### DIFF
--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -14,7 +14,7 @@ import logging
 ###############
 import numpy as np
 from ophyd import PositionerBase
-from ophyd import Component, FormattedComponent
+from ophyd import Component
 from ophyd.utils import LimitError
 from ophyd.status import wait as status_wait
 
@@ -22,7 +22,6 @@ from ophyd.status import wait as status_wait
 # SLAC #
 ########
 from pcdsdevices.device import Device
-from pcdsdevices.component import Component
 from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO)
 from pcdsdevices.epics.epicsmotor import EpicsMotor
 

--- a/hxrsnd/diode.py
+++ b/hxrsnd/diode.py
@@ -11,13 +11,12 @@ import logging
 ###############
 # Third Party #
 ###############
-
+from ophyd import Component
 
 ########
 # SLAC #
 ########
 from pcdsdevices.device import Device
-from pcdsdevices.component import Component
 
 ##########
 # Module #

--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -936,6 +936,9 @@ class Energy1Macro(DelayTowerMacro):
         confirm_move : bool, optional
             Prompts the user for confirmation.
 
+        use_diag : bool, optional
+            Add the diagnostic motor to the list of motors to verify.
+        
         Returns
         -------
         allowed : bool
@@ -1178,6 +1181,9 @@ class Energy2Macro(MacroBase):
         confirm_move : bool, optional
             Prompts the user for confirmation.
 
+        use_diag : bool, optional
+            Add the diagnostic motor to the list of motors to verify.
+        
         Returns
         -------
         allowed : bool

--- a/hxrsnd/plans.py
+++ b/hxrsnd/plans.py
@@ -256,7 +256,7 @@ def rocking_curve(detector, motor, read_field, coarse_step, fine_step,
     return fit
 
 def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True, 
-                md=None):
+                md=None, *args, **kwargs):
     """
     Performs a linear scan using the inputted motor, optionally using the
     diagnostics, and optionally moving the motor back to the original start
@@ -314,16 +314,15 @@ def linear_scan(motor, start, stop, num, use_diag=True, return_to_start=True,
             grp = _short_uid('set')
             yield Msg('checkpoint')
             # Set wait to be false in set once the status object is implemented
-            yield Msg('set', motor, step, group=grp, verify_move=False, 
-                      use_diag=use_diag)
+            yield Msg('set', motor, step, group=grp, *args, **kwargs)
             yield Msg('wait', None, group=grp)
             yield from trigger_and_read([motor])
 
         if return_to_start:
             logger.info("\nScan complete. Moving back to starting position: {0}"
                         "\n".format(start))
-            yield Msg('set', motor, start, group=grp, verify_move=False, 
-                    use_diag=use_diag)
+            yield Msg('set', motor, start, group=grp, use_diag=use_diag, *args,
+                      **kwargs)
             yield Msg('wait', None, group=grp)
 
     return (yield from inner_scan())


### PR DESCRIPTION
Overview
=======
Adding a fix to allow all motors to be passed to the scan. Quick additions elsewhere - changing component to be the default version from `ophyd`.