### PR TITLE
Wave8

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   #Grab all dependencies
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig simplejson pandas opencv=3.1 coverage pip wheel ophyd==1.0.0 bluesky==1.0.0 event-model=1.3.0 pytest -c conda-forge -c lightsource2-tag
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION swig simplejson pydm psbeam pswalker pcds-devices pandas opencv=3.1 coverage pip wheel ophyd==1.0.0 bluesky==1.0.0 event-model=1.3.0 pytest -c pydm-dev -c skywalker-dev -c conda-forge -c gsecars -c lightsource2-tag
   #Launch Conda environment
   - source activate test-environment
   #Install pedl

--- a/docs/source/plans.rst
+++ b/docs/source/plans.rst
@@ -1,4 +1,43 @@
 Alignment Plans
 +++++++++++++++
 
+Running the Rocking Curve
+-------------------------
+The rocking curve does two successive step scans, using the maximum of the
+first to center the finer scan on the second. There are a number of fields to
+configure and play with but lets start simple:
+
+.. code:: python
+
+   rock = rocking_curve(wave8.diode_1, hxrsnd.th2, 'peakT', 1, 0.1,
+                        bounds=(0, 20), average=100)
+
+   RE(rock)
+
+The code above runs a step scan from 0 to 20 in steps of 1, reading the diode
+at each point. A fit is processed at the end and a second scan is started 5
+units to the left of the calculated center and runs using 0.1 as the step size
+until we reach 5 units greater than our first result. Finally, the rotation
+axis is centered with our new maximum. 
+
+If you want to use change the range of the second finer scan, you can use the
+`fine_space` keyword. In addition, the `lmfit` model that does our fitting
+accepts an initial guess. This can be useful to make an assumption about the
+system to improve the accuracy and dependability of the scan. Using this
+parameter would look like:
+
+.. code:: python
+   rock = rocking_curve(wave8.diode_1, hxrsnd.th2, 'peakT', 1, 0.1,
+                        bounds=(0, 20), average=100,
+                        initial_guess = {'sigma' : 1.0,
+                                         'center' : 10.0,
+                                         'amplitude' : 1220.4})
+
+   RE(rock)
+
+
+Documentation
+-------------
+.. autofunction:: hxrsnd.rocking_curve
+
 .. autofunction:: hxrsnd.maximize_lorentz

--- a/hxrsnd/diode.py
+++ b/hxrsnd/diode.py
@@ -11,12 +11,13 @@ import logging
 ###############
 # Third Party #
 ###############
-from ophyd import Component
+from ophyd import EpicsSignalRO
 
 ########
 # SLAC #
 ########
 from pcdsdevices.device import Device
+from pcdsdevices.component import Component as C, FormattedComponent as FC
 
 ##########
 # Module #
@@ -47,8 +48,8 @@ class HamamatsuXMotionDiode(Device):
     """
     Class for the Hamamatsu diode but with an X motor
     """
-    diode = Component(HamamatsuDiode, ":DIODE")
-    x = Component(DiodeAero, ":X")
+    diode = C(HamamatsuDiode, ":DIODE")
+    x = C(DiodeAero, ":X")
     def __init__(self, prefix, name=None, *args, **kwargs):
         super().__init__(prefix, name=name, *args, **kwargs)
 
@@ -57,6 +58,58 @@ class HamamatsuXYMotionCamDiode(HamamatsuXMotionDiode):
     """
     Class for the Hamamatsu diode but with X and Y motors
     """
-    y = Component(DiodeAero, ":Y")
-    # cam = Component(GigeDetector, ":CAM")
-    
+    y = C(DiodeAero, ":Y")
+    cam = C(GigeDetector, ":CAM")
+
+
+class DiodeIO(Device):
+    """
+    Peak information for a Wave8 input
+
+    Parameters
+    ----------
+    prefix : str
+        Base name of device
+
+    channel : int
+        Channel number of device
+
+    name : str
+        Name of Wave8 device
+    """
+    peakA = FC(EpicsSignalRO,'{self.prefix}:_peakA_{self.channel}')
+    peakT = FC(EpicsSignalRO,'{self.prefix}:_peakT_{self.channel}')
+
+    def __init__(self, prefix, channel, name, *,
+                 read_attrs=None, **kwargs):
+        #Store the channel
+        self.channel = channel
+        #Default read attributes
+        if read_attrs is None:
+            read_attrs = ['peakT']
+        #Initialize device
+        super().__init__(prefix, name=name, read_attrs=read_attrs, **kwargs)
+
+
+class Wave8(Device):
+    """
+    Wave8 Device
+
+    A system of sixteen diodes, each with two peaks; A and T.
+    """
+    diode_0  = C(DiodeIO, '', channel=0,  name='Diode 0')
+    diode_1  = C(DiodeIO, '', channel=1,  name='Diode 1')
+    diode_2  = C(DiodeIO, '', channel=2,  name='Diode 2')
+    diode_3  = C(DiodeIO, '', channel=3,  name='Diode 3')
+    diode_4  = C(DiodeIO, '', channel=4,  name='Diode 4')
+    diode_5  = C(DiodeIO, '', channel=5,  name='Diode 5')
+    diode_6  = C(DiodeIO, '', channel=6,  name='Diode 6')
+    diode_7  = C(DiodeIO, '', channel=7,  name='Diode 7')
+    diode_8  = C(DiodeIO, '', channel=8,  name='Diode 8')
+    diode_9  = C(DiodeIO, '', channel=9,  name='Diode 9')
+    diode_10 = C(DiodeIO, '', channel=10, name='Diode 10')
+    diode_11 = C(DiodeIO, '', channel=11, name='Diode 11')
+    diode_12 = C(DiodeIO, '', channel=12, name='Diode 12')
+    diode_13 = C(DiodeIO, '', channel=13, name='Diode 13')
+    diode_14 = C(DiodeIO, '', channel=14, name='Diode 14')
+    diode_15 = C(DiodeIO, '', channel=15, name='Diode 15')

--- a/hxrsnd/tests/conftest.py
+++ b/hxrsnd/tests/conftest.py
@@ -68,10 +68,13 @@ def set_level(pytestconfig):
 @pytest.fixture(scope='function')
 def fresh_RE(request):
     return RE(request)
-    
-def get_classes_in_module(module, subcls=None):
+
+
+def get_classes_in_module(module, subcls=None, blacklist=None):
     classes = []
-    all_classes = inspect.getmembers(module)
+    blacklist = blacklist or list()
+    all_classes = [(_, cls) for (_, cls) in inspect.getmembers(module)
+                          if cls not in blacklist]
     for _, cls in all_classes:
         try:
             if cls.__module__ == module.__name__:
@@ -83,7 +86,7 @@ def get_classes_in_module(module, subcls=None):
                         continue
                 classes.append(cls)
         except AttributeError:
-            pass    
+            pass
     return classes
 
 # Create a fake epics device

--- a/hxrsnd/tests/conftest.py
+++ b/hxrsnd/tests/conftest.py
@@ -92,5 +92,5 @@ def get_classes_in_module(module, subcls=None, blacklist=None):
 # Create a fake epics device
 @using_fake_epics_pv
 def fake_device(device, name="TEST"):
-    return device(name)
+    return device(name, name=name)
 

--- a/hxrsnd/tests/test_diode.py
+++ b/hxrsnd/tests/test_diode.py
@@ -29,7 +29,8 @@ from hxrsnd.utils import get_logger
 logger = get_logger(__name__, log_file=False)
 
 @using_fake_epics_pv
-@pytest.mark.parametrize("dev", get_classes_in_module(diode, Device))
+@pytest.mark.parametrize("dev", get_classes_in_module(diode, Device,
+                                                      blacklist=[diode.DiodeIO]))
 def test_diode_devices_instantiate_and_run_ophyd_functions(dev):
     device = fake_device(dev)
     assert(isinstance(device.read(), OrderedDict))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 git+https://github.com/slaclab/lightpath#egg=lightpath
-git+https://github.com/slaclab/pcds-devices#egg=pcds-devices
-git+https://github.com/slaclab/pswalker#egg=pswalker
 super_state_machine
 lmfit
 numpy

--- a/screens/diode.ui
+++ b/screens/diode.ui
@@ -1,0 +1,954 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1041</width>
+    <height>845</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Raw</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <layout class="QGridLayout" name="raw">
+         <item row="8" column="1">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_6">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_15&quot;, &quot;name&quot;: &quot;Diode 7&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+             <kerning>false</kerning>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>t1.d</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label">
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>di</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_4">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_13&quot;, &quot;name&quot;: &quot;Diode 5&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_5">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_14&quot;, &quot;name&quot;: &quot;Diode 6&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_3">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>dd</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="PyDMLabel" name="PyDMLabel_2">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>dci</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_8&quot;, &quot;name&quot;: &quot;Diode 0&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>2.000000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="PyDMLabel" name="PyDMLabel_4">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>dcc</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_3">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_12&quot;, &quot;name&quot;: &quot;Diode 4&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_8">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_11&quot;, &quot;name&quot;: &quot;Diode 3&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_2">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_9&quot;, &quot;name&quot;: &quot;Diode 1&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="PyDMTimePlot" name="PyDMTimePlot_7">
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <property name="title" stdset="0">
+            <string/>
+           </property>
+           <property name="showLegend" stdset="0">
+            <bool>false</bool>
+           </property>
+           <property name="curves" stdset="0">
+            <stringlist>
+             <string>{&quot;channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_10&quot;, &quot;name&quot;: &quot;Diode 2&quot;, &quot;color&quot;: &quot;white&quot;}</string>
+            </stringlist>
+           </property>
+           <property name="bufferSize" stdset="0">
+            <number>15000</number>
+           </property>
+           <property name="timeSpan" stdset="0">
+            <double>90.000000000000000</double>
+           </property>
+           <property name="updateInterval" stdset="0">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="autoRangeY" stdset="0">
+            <bool>true</bool>
+           </property>
+           <property name="minYRange" stdset="0">
+            <double>-502.000000000000000</double>
+           </property>
+           <property name="maxYRange" stdset="0">
+            <double>1000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_5">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>t4.d</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="PyDMLabel" name="PyDMLabel_6">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>dco</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="PyDMLabel" name="PyDMLabel_7">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>14</pointsize>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="toolTip">
+            <string/>
+           </property>
+           <property name="whatsThis">
+            <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+           </property>
+           <property name="text">
+            <string>do</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Correlation</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="0">
+        <widget class="PyDMLabel" name="PyDMLabel_8">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="text">
+          <string>dco x dcc</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_9">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="text">
+          <string>t4.d x dd</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="PyDMLabel" name="PyDMLabel_10">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="text">
+          <string>t4d x dco</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="PyDMLabel" name="PyDMLabel_11">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="font">
+          <font>
+           <pointsize>14</pointsize>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    A QLabel with support for Channels and more from PyDM
+
+    Parameters
+    ----------
+    parent : QWidget
+        The parent widget for the Label
+    init_channel : str, optional
+        The channel to be used by the widget.
+    </string>
+         </property>
+         <property name="text">
+          <string>do x di</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="PyDMScatterPlot" name="PyDMScatterPlot">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    </string>
+         </property>
+         <property name="curves" stdset="0">
+          <stringlist>
+           <string>{&quot;y_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_9&quot;, &quot;x_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_8&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="PyDMScatterPlot" name="PyDMScatterPlot_3">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    </string>
+         </property>
+         <property name="curves" stdset="0">
+          <stringlist>
+           <string>{&quot;y_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_15&quot;, &quot;x_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_12&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="PyDMScatterPlot" name="PyDMScatterPlot_4">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    </string>
+         </property>
+         <property name="curves" stdset="0">
+          <stringlist>
+           <string>{&quot;y_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_15&quot;, &quot;x_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_9&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="PyDMScatterPlot" name="PyDMScatterPlot_2">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>
+    PyDMScatterPlot is a widget to plot one scalar value against another.
+    Multiple scalar pairs can be plotted on the same plot.  Each pair has
+    a buffer which stores previous values.  All values in the buffer are
+    drawn.  The buffer size for each pair is user configurable.
+
+    Parameters
+    ----------
+    parent : optional
+        The parent of this widget.
+    init_x_channels: optional
+        init_x_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If not specified, y-axis
+        waveforms will be plotted against their indices.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    init_y_channels: optional
+        init_y_channels can be a string with the address for a channel, or a list of
+        strings, each containing an address for a channel.  If a list is specified for
+        both init_x_channels and init_y_channels, they both must have the same length.
+        If a single x channel was specified, and a list of y channels are specified, all
+        y channels will be plotted against the same x channel.
+    background: optional
+        The background color for the plot.  Accepts any arguments that pyqtgraph.mkColor
+        will accept.
+    </string>
+         </property>
+         <property name="curves" stdset="0">
+          <stringlist>
+           <string>{&quot;y_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_10&quot;, &quot;x_channel&quot;: &quot;ca://XCS:SND:DIO:_peakT_14&quot;, &quot;name&quot;: &quot;&quot;, &quot;color&quot;: &quot;white&quot;, &quot;lineStyle&quot;: 0, &quot;lineWidth&quot;: 1, &quot;symbol&quot;: &quot;o&quot;, &quot;symbolSize&quot;: 10, &quot;redraw_mode&quot;: 2}</string>
+          </stringlist>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>PyDMTimePlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.timeplot</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMScatterPlot</class>
+   <extends>QGraphicsView</extends>
+   <header>pydm.widgets.scatterplot</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Description
Includes a basic class for diodes and the Wave8 has a whole. The easiest way to instantiate it is probably:

```python
wave8 = hxrsnd.diodes.Wave8('XCS:SND:DIO', name='Wave 8')
```
Each diode is then added as `diode_0`, `diode_1` e.t.c. We can probably clean this up in a later PR giving these actual names. I included both peaks for completeness, but for the SnD I think they only care about `peakT`.

This PR also has a pydm user interface with both individual diode plots and four correlation plots requested by Diling. **These need the newest PyDM release** as there was a bug fix for high rate data. https://github.com/slaclab/pydm/pull/171

Just launch it with

```bash
pydm hxrsnd/screens/diode.ui
```

Also added some templates for Issues and Pull Requests

## Documentation
Minimal docstrings on class. Added a lengthy description on how to use `rocking_curve`

## Tests
Wave8 class and DiodeIO are both instantiated by the existing test in `hxrsnd/tests/test_diode.py`. Because `DiodeIO` needs special keywords it could not be tested in the same way individually. It is however called by the `Wave8` class. In order to avoid calling `DiodeIO` separately I added a `blacklist` keyword to the `get_classes_in_module` keyword

## Screenshots
<img width="868" alt="screen shot 2017-11-16 at 10 00 39 pm" src="https://user-images.githubusercontent.com/25753048/32931553-9d5dd73c-cb19-11e7-8019-b2a9d3cceb0f.png">
