### PR TITLE
ENH: Changing conda environment to use pcds-0.2.0

### DIFF
--- a/bin/run_snd
+++ b/bin/run_snd
@@ -4,22 +4,32 @@
 unset LD_LIBRARY_PATH
 unset PYTHONPATH
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/reg/common/package/epicsca/3.14.12/lib/rhel6-x86_64
-export PATH=/reg/g/pcds/pyps/conda/rhel6/bin:$PATH
+export PATH=/reg/g/pcds/pyps/conda/py36/bin:$PATH
 
 # These have to be included otherwise there you get the following error then a
 # seg fault:
 #       QXcbConnection: Could not connect to display
 # This needs to point to the conda env being used
-export QT_XKB_CONFIG_ROOT='/reg/g/pcds/pyps/conda/rhel6/envs/snd_opr/lib'
+export QT_XKB_CONFIG_ROOT='/reg/g/pcds/pyps/conda/py36/envs/pcds-0.2.0/lib'
 # This ensures the terminal doesn't totally screw up
 export QT_QPA_PLATFORM='offscreen'
 
 # Activate the snd_opr conda environment
-source activate snd_opr
+source activate pcds-0.2.0
 
 # Get the directory of this script resolving soft links
 FILE=`readlink -f $0`
 SCRIPTPATH=`dirname $FILE`
+
+# Get the directory of snd project
+SNDPATH=$(readlink --canonicalize $SCRIPTPATH/../..)
+
+# Add required modules to the python path
+PYTHONPATH=$SNDPATH/pcds-devices:$PYTHONPATH # pcds-devices
+PYTHONPATH=$SNDPATH/pswalker:$PYTHONPATH     # pswalker
+PYTHONPATH=$SNDPATH/HXRSnD:$PYTHONPATH       # HXRSnD
+PYTHONPATH=$SNDPATH/pydm:$PYTHONPATH         # PyDM
+export PYTHONPATH
 
 # Start the ipython shell using the snd environment
 ipython -i $SCRIPTPATH/run_snd.py


### PR DESCRIPTION
Overview
-------------
This PR changes conda environment used to be the central pcds-0.2.0 env rather than the rhel6 one.