### PR TITLE
ENH: Added state as a component for aerotech motors

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -27,10 +27,10 @@ from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO, FakeSignal)
 # Module #
 ##########
 from .pneumatic import PressureSwitch
-from .utils import get_logger, absolute_submodule_path
+from .utils import absolute_submodule_path, as_list
 from .exceptions import MotorDisabled, MotorFaulted, BadN2Pressure
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class AeroBase(EpicsMotor):
@@ -109,7 +109,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         wait : bool, optional
@@ -126,8 +126,8 @@ class AeroBase(EpicsMotor):
         try:
             # Wait for the status to complete
             if wait:
-                for s in list(status):
-                    status_wait(status, self._timeout)
+                for s in as_list(status):
+                    status_wait(s, self._timeout)
 
             # Notify the user
             if msg is not None:
@@ -154,7 +154,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
         
         Returns
@@ -164,7 +164,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.home_forward.set(1)
         return self._status_print(status, "Homing '{0}' forward.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     def homr(self, ret_status=False, print_set=True):
         """
@@ -175,7 +175,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -185,7 +185,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.home_reverse.set(1)
         return self._status_print(status, "Homing '{0}' in reverse.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     def move(self, position, wait=False, check_status=True, ret_status=True, 
              print_move=False, *args, **kwargs):
@@ -471,7 +471,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -481,7 +481,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.power.set(1)
         return self._status_print(status, "Enabled motor '{0}'.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     def disable(self, ret_status=False, print_set=True):
         """
@@ -492,7 +492,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -502,7 +502,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.power.set(0)
         return self._status_print(status, "Disabled motor '{0}'.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     @property
     def enabled(self):
@@ -525,7 +525,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -535,7 +535,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.clear_error.set(1)
         return self._status_print(status, "Cleared motor '{0}'.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     def reconfig(self, ret_status=False, print_set=True):
         """
@@ -546,7 +546,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -556,7 +556,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.config.set(1)
         return self._status_print(status, "Reconfigured motor '{0}'.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     @property
     def faulted(self):
@@ -579,7 +579,7 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
@@ -589,7 +589,7 @@ class AeroBase(EpicsMotor):
         """
         status = self.zero_all_proc.set(1)
         return self._status_print(status, "Zeroed motor '{0}'.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     @property
     def state(self):
@@ -619,13 +619,13 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
         -------
         Status
-            The status object for setting the config signal.        
+            The status object for setting the state signal.        
         """
         return self.set_state(val, ret_status, print_set)
 
@@ -642,13 +642,13 @@ class AeroBase(EpicsMotor):
         ret_status : bool, optional
             Return the status object of the set.
 
-        print_move : bool, optional
+        print_set : bool, optional
             Print a short statement about the set.
 
         Returns
         -------
         Status
-            The status object for setting the config signal.        
+            The status object for setting the state signal.        
         """
         # Make sure it is in title case if it's a string
         val = state
@@ -665,18 +665,31 @@ class AeroBase(EpicsMotor):
         status = self.state_component.set(val)
 
         return self._status_print(status, "Changed state to '{0}'.".format(
-            self.desc), print_set=print_set)
+            val), print_set=print_set, ret_status=ret_status)
 
-    def ready_motor(self):
+    def ready_motor(self, ret_status=False, print_set=True):
         """
         Sets the motor to the ready state by clearing any errors, enabling it,
         and setting the state to be 'Go'.
+
+        Parameters
+        ----------
+        ret_status : bool, optional
+            Return the status object of the set.
+
+        print_set : bool, optional
+            Print a short statement about the set.
+
+        Returns
+        -------
+        Status
+            The status object for all the sets.        
         """
-        status = self.clear(ret_status=True, print_set=False)
-        status += self.enable(ret_status=True, print_set=False)
-        status += self.set_state("Go", ret_status=True, print_set=False)
+        status = [self.clear(ret_status=True, print_set=False)]
+        status.append(self.enable(ret_status=True, print_set=False))
+        status.append(self.set_state("Go", ret_status=True, print_set=False))
         return self._status_print(status, "Motor '{0}' is now ready.".format(
-            self.desc), print_set=print_set)
+            self.desc), print_set=print_set, ret_status=ret_status)
 
     def expert_screen(self, print_msg=True):
         """

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -29,9 +29,9 @@ from pcdsdevices.epics.epicsmotor import EpicsMotor
 # Module #
 ##########
 from .exceptions import MotorDisabled, MotorError
-from .utils import get_logger, absolute_submodule_path
+from .utils import absolute_submodule_path
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class EccController(Device):

--- a/hxrsnd/bragg.py
+++ b/hxrsnd/bragg.py
@@ -19,9 +19,8 @@ import numpy as np
 ##########
 # Module #
 ##########
-from .utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Globals
 

--- a/hxrsnd/detectors.py
+++ b/hxrsnd/detectors.py
@@ -17,9 +17,8 @@ from pcdsdevices.epics.areadetector.detectors import DetectorBase
 ##########
 # Module #
 ##########
-from .utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class GigeCam(CamBase):

--- a/hxrsnd/diode.py
+++ b/hxrsnd/diode.py
@@ -21,11 +21,10 @@ from pcdsdevices.device import Device
 ##########
 # Module #
 ##########
-from .utils import get_logger
 from .aerotech import DiodeAero
 from .detectors import GigeDetector
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class DiodeBase(Device):

--- a/hxrsnd/exceptions.py
+++ b/hxrsnd/exceptions.py
@@ -8,12 +8,8 @@ Exceptions for the SnD system.
 ############
 import logging
 
-##########
-# Module #
-##########
-from .utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 # Exceptions
 

--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -157,7 +157,6 @@ class MacroBase(Device):
 
         use_diag : bool, optional
             Move the daignostic motors to align with the beam.
-
         use_calib : bool, optional
             Use the configurated calibration parameters
         
@@ -747,31 +746,31 @@ class DelayMacro(DelayTowerMacro):
     """
     Macro-motor for the delay macro-motor.
     """
-    @property
-    def aligned(self, rtol=0, atol=0.001):
-        """
-        Checks to see if the towers are in aligned in energy and delay.
+    # @property
+    # def aligned(self, rtol=0, atol=0.001):
+    #     """
+    #     Checks to see if the towers are in aligned in energy and delay.
 
-        Parameters
-        ----------
-        rtol : float, optional
-            Relative tolerance to use when comparing value differences.
+    #     Parameters
+    #     ----------
+    #     rtol : float, optional
+    #         Relative tolerance to use when comparing value differences.
         
-        atol : float, optional
-            Absolute tolerance to use when comparing value differences.
+    #     atol : float, optional
+    #         Absolute tolerance to use when comparing value differences.
 
-        Returns
-        -------
-        is_aligned : bool
-            True if the towers are aligned, False if not.
-        """
-        t1_delay = self._length_to_delay(self.parent.t1.length)
-        t4_delay = self._length_to_delay(self.parent.t4.length)
-        is_aligned = np.isclose(t1_delay, t4_delay, atol=atol, rtol=rtol)
-        if not is_aligned:
-            logger.warning("Delay mismatch between t1 and t4. t1: {0:.3f}ps, "
-                           "t4: {1:.3f}ps".format(t1_delay, t4_delay))
-        return is_aligned
+    #     Returns
+    #     -------
+    #     is_aligned : bool
+    #         True if the towers are aligned, False if not.
+    #     """
+    #     t1_delay = self._length_to_delay(self.parent.t1.length)
+    #     t4_delay = self._length_to_delay(self.parent.t4.length)
+    #     is_aligned = np.isclose(t1_delay, t4_delay, atol=atol, rtol=rtol)
+    #     if not is_aligned:
+    #         logger.warning("Delay mismatch between t1 and t4. t1: {0:.3f}ps, "
+    #                        "t4: {1:.3f}ps".format(t1_delay, t4_delay))
+    #     return is_aligned
 
     def _length_to_delay(self, L=None, theta1=None, theta2=None):
         """
@@ -841,13 +840,13 @@ class DelayMacro(DelayTowerMacro):
         # Convert to length and add the body of the string
         length = self._delay_to_length(delay)
         for tower in self._delay_towers:
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                 tower.L.desc, tower.length, length)
 
         # Add the diagnostic move
         if use_diag:
             position_dd = self._get_delay_diagnostic_position(delay)
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                 self.parent.dd.x.desc, self.parent.dd.x.position, position_dd)
 
         # Prompt the user for a confirmation or return the string
@@ -970,7 +969,8 @@ class DelayMacro(DelayTowerMacro):
         """
         return self._length_to_delay()
     
-    def set_position(self, delay=None, print_set=True, use_diag=True):
+    def set_position(self, delay=None, print_set=True, use_diag=True,
+                     verify_move=True):
         """
         Sets the current positions of the motors in the towers to be the 
         calculated positions based on the inputted energies or delay.
@@ -982,7 +982,16 @@ class DelayMacro(DelayTowerMacro):
         
         print_set : bool, optional
             Print a message to the console that the set has been made.
+
+        verify_move : bool, optional
+            Prints the current system state and a proposed system state and
+            then prompts the user to accept the proposal before changing the
+            system.
         """            
+        # Prompt the user about the move before making it
+        if verify_move and self._verify_move(delay, use_diag=use_diag):
+            return
+
         length = self._delay_to_length(delay)
         
         # Set the position of each delay stage
@@ -991,7 +1000,7 @@ class DelayMacro(DelayTowerMacro):
                 
         # Diagnostic
         if use_diag:
-            position_dd = self._get_delay_diagnostic_position(E1, E2, delay)
+            position_dd = self._get_delay_diagnostic_position(delay=delay)
             self.parent.dd.x.set_position(position_dd, print_set=False)            
 
         if print_set:
@@ -1001,31 +1010,31 @@ class Energy1Macro(DelayTowerMacro):
     """
     Macro-motor for the energy 1 macro-motor.
     """
-    @property
-    def aligned(self, rtol=0, atol=0.001):
-        """
-        Checks to see if the towers are in aligned in energy and delay.
+    # @property
+    # def aligned(self, rtol=0, atol=0.001):
+    #     """
+    #     Checks to see if the towers are in aligned in energy and delay.
 
-        Parameters
-        ----------
-        rtol : float, optional
-            Relative tolerance to use when comparing value differences.
+    #     Parameters
+    #     ----------
+    #     rtol : float, optional
+    #         Relative tolerance to use when comparing value differences.
         
-        atol : float, optional
-            Absolute tolerance to use when comparing value differences.
+    #     atol : float, optional
+    #         Absolute tolerance to use when comparing value differences.
 
-        Returns
-        -------
-        is_aligned : bool
-            True if the towers are aligned, False if not.
-        """
-        t1 = self.parent.t1
-        t4 = self.parent.t4
-        is_aligned = np.isclose(t1.energy, t4.energy, atol=atol, rtol=rtol)
-        if not is_aligned:
-            logger.warning("Energy mismatch between t1 and t4. t1: {0:.3f}  eV,"
-                           " t4: {1:.3f} eV".format(t1.energy, t4.energy))                        
-        return is_aligned
+    #     Returns
+    #     -------
+    #     is_aligned : bool
+    #         True if the towers are aligned, False if not.
+    #     """
+    #     t1 = self.parent.t1
+    #     t4 = self.parent.t4
+    #     is_aligned = np.isclose(t1.energy, t4.energy, atol=atol, rtol=rtol)
+    #     if not is_aligned:
+    #         logger.warning("Energy mismatch between t1 and t4. t1: {0:.3f}  eV,"
+    #                        " t4: {1:.3f} eV".format(t1.energy, t4.energy))                        
+    #     return is_aligned
 
 
     def _length_to_delay(self, L=None, theta1=None, theta2=None):
@@ -1097,12 +1106,12 @@ class Energy1Macro(DelayTowerMacro):
         for tower in self._delay_towers:
             for motor, position in zip(tower._energy_motors,
                                        tower._get_move_positions(E1)):
-                string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+                string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                     motor.desc, motor.position, position)
 
         if use_diag:
             position_dd = self._get_delay_diagnostic_position(E1)
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                 self.parent.dd.x.desc, self.parent.dd.x.position, position_dd)
 
         # Prompt the user for a confirmation or return the string
@@ -1218,7 +1227,8 @@ class Energy1Macro(DelayTowerMacro):
         """
         return self.parent.t1.energy
 
-    def set_position(self, E1=None, print_set=True):
+    def set_position(self, E1=None, print_set=True, verify_move=True,
+                     use_diag=True):
         """
         Sets the current positions of the motors in the towers to be the 
         calculated positions based on the inputted energies or delay.
@@ -1230,18 +1240,29 @@ class Energy1Macro(DelayTowerMacro):
         
         print_set : bool, optional
             Print a message to the console that the set has been made.
+
+        verify_move : bool, optional
+            Prints the current system state and a proposed system state and
+            then prompts the user to accept the proposal before changing the
+            system.
+
+        use_diag : bool, optional
+            Move the daignostic motors to align with the beam.
         """
-        theta1 = bragg_angle(E=E1)
+        # Prompt the user about the move before making it
+        if verify_move and self._verify_move(E1, use_diag=use_diag):
+            return
 
         # Set position of each E1 motor in each delay tower
         for tower in self._delay_towers:
             for motor, pos in zip(tower._energy_motors,
-                                  tower._get_move_positions(theta1)):
+                                  tower._get_move_positions(E1)):
                 motor.set_position(pos, print_set=False)
 
         # Set the diagnostic
-        position_dd = self._get_delay_diagnostic_position(E1=E1)
-        self.parent.dd.x.set_position(position_dd, print_set=False)
+        if use_diag:
+            position_dd = self._get_delay_diagnostic_position(E1=E1)
+            self.parent.dd.x.set_position(position_dd, print_set=False)
 
         # Log the set
         if print_set is True:
@@ -1286,12 +1307,12 @@ class Energy1CCMacro(Energy1Macro):
 
         # Get move for each motor in the delay towers
         for tower in self._delay_towers:
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                     tower.tth.desc, tower.tth.position, 2*bragg_angle(E1))
 
         if use_diag:
             position_dd = self._get_delay_diagnostic_position(E1)
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                 self.parent.dd.x.desc, self.parent.dd.x.position, position_dd)
 
         # Prompt the user for a confirmation or return the string
@@ -1382,7 +1403,8 @@ class Energy1CCMacro(Energy1Macro):
 
         return status
 
-    def set_position(self, E1=None, print_set=True):
+    def set_position(self, E1=None, print_set=True, verify_move=True,
+                     use_diag=True):
         """
         Sets the current positions of the motors in the towers to be the 
         calculated positions based on the inputted energies or delay.
@@ -1394,18 +1416,27 @@ class Energy1CCMacro(Energy1Macro):
         
         print_set : bool, optional
             Print a message to the console that the set has been made.
+
+        verify_move : bool, optional
+            Prints the current system state and a proposed system state and
+            then prompts the user to accept the proposal before changing the
+            system.
+
+        use_diag : bool, optional
+            Move the daignostic motors to align with the beam.
         """
-        theta1 = bragg_angle(E=E1)
+        # Prompt the user about the move before making it
+        if verify_move and self._verify_move(E1, use_diag=use_diag):
+            return
 
         # Set position of each E1 motor in each delay tower
         for tower in self._delay_towers:
-            for motor, pos in zip(tower._energy_motors,
-                                  tower._get_move_positions(theta1)):
-                motor.set_position(pos, print_set=False)
+            tower.tth.set_position(2*bragg_angle(E1), print_set=False)
 
         # Set the diagnostic
-        position_dd = self._get_delay_diagnostic_position(E1=E1)
-        self.parent.dd.x.set_position(position_dd, print_set=False)
+        if use_diag:
+            position_dd = self._get_delay_diagnostic_position(E1=E1)
+            self.parent.dd.x.set_position(position_dd, print_set=False)
 
         # Log the set
         if print_set is True:
@@ -1443,31 +1474,31 @@ class Energy2Macro(MacroBase):
         position = 2*cosd(theta2)*self.gap
         return position
     
-    @property
-    def aligned(self, rtol=0, atol=0.001):
-        """
-        Checks to see if the towers are in aligned in energy and delay.
+    # @property
+    # def aligned(self, rtol=0, atol=0.001):
+    #     """
+    #     Checks to see if the towers are in aligned in energy and delay.
 
-        Parameters
-        ----------
-        rtol : float, optional
-            Relative tolerance to use when comparing value differences.
+    #     Parameters
+    #     ----------
+    #     rtol : float, optional
+    #         Relative tolerance to use when comparing value differences.
         
-        atol : float, optional
-            Absolute tolerance to use when comparing value differences.
+    #     atol : float, optional
+    #         Absolute tolerance to use when comparing value differences.
 
-        Returns
-        -------
-        is_aligned : bool
-            True if the towers are aligned, False if not.
-        """
-        t2 = self.parent.t2
-        t3 = self.parent.t3
-        is_aligned = np.isclose(t2.energy, t3.energy, atol=atol, rtol=rtol)
-        if not is_aligned:
-            logger.warning("Energy mismatch between t2 and t3. t1: {0:.3f} eV, "
-                           "t4: {1:.3f} eV".format(t2.energy, t3.energy))
-        return is_aligned
+    #     Returns
+    #     -------
+    #     is_aligned : bool
+    #         True if the towers are aligned, False if not.
+    #     """
+    #     t2 = self.parent.t2
+    #     t3 = self.parent.t3
+    #     is_aligned = np.isclose(t2.energy, t3.energy, atol=atol, rtol=rtol)
+    #     if not is_aligned:
+    #         logger.warning("Energy mismatch between t2 and t3. t1: {0:.3f} eV, "
+    #                        "t4: {1:.3f} eV".format(t2.energy, t3.energy))
+    #     return is_aligned
 
     def _verify_move(self, E2, string="", use_header=True, confirm_move=True,
                      use_diag=True):
@@ -1506,13 +1537,13 @@ class Energy2Macro(MacroBase):
         for tower in self._channelcut_towers:
             for motor, position in zip(tower._energy_motors,
                                        tower._get_move_positions(E2)):
-                string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+                string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                     motor.desc, motor.position, position)
 
         # Get move for the channel cut diagnostic
         if use_diag:
             position_dcc = self._get_channelcut_diagnostic_position(E2)
-            string += "\n{:<15}|{:^15.3f}|{:^15.3f}".format(
+            string += "\n{:<15}|{:^15.4f}|{:^15.4f}".format(
                 self.parent.dcc.x.desc, self.parent.dcc.x.position, 
                 position_dcc)
             
@@ -1609,7 +1640,8 @@ class Energy2Macro(MacroBase):
         """
         return self.parent.t2.energy
 
-    def set_position(self, E2=None, print_set=True):
+    def set_position(self, E2=None, print_set=True, verify_move=True,
+                     use_diag=True):
         """
         Sets the current positions of the motors in the towers to be the 
         calculated positions based on the inputted energies or delay.
@@ -1621,13 +1653,23 @@ class Energy2Macro(MacroBase):
         
         print_set : bool, optional
             Print a message to the console that the set has been made.
+
+        verify_move : bool, optional
+            Prints the current system state and a proposed system state and
+            then prompts the user to accept the proposal before changing the
+            system.
+
+        use_diag : bool, optional
+            Move the daignostic motors to align with the beam.
         """
-        theta2 = bragg_angle(E=E2)
+        # Prompt the user about the move before making it
+        if verify_move and self._verify_move(E2, use_diag=use_diag):
+            return
 
         # Set position of each E2 motor in each channel cut tower
         for tower in self._channelcut_towers:
             for motor, pos in zip(tower._energy_motors, 
-                                  tower._get_move_positions(theta1)):
+                                  tower._get_move_positions(E2)):
                 motor.set_position(pos, print_set=False)
 
         # Move the cc diagnostic as well
@@ -1637,11 +1679,3 @@ class Energy2Macro(MacroBase):
         # Log the set
         if print_set is True:
             logger.info("Setting positions for E2 to {0}.".format(E2))
-
-
-# Notes
-
-# Add checks for faults after the move
-# Add signal for stop and go pv
-# For E, if each energy is off by more than 1 eV, then report a warning, but
-# then do a relative move on each of their current positions.

--- a/hxrsnd/macromotor.py
+++ b/hxrsnd/macromotor.py
@@ -24,11 +24,11 @@ from pcdsdevices.device import Device
 ##########
 # Module #
 ##########
-from .utils import get_logger, as_list, flatten
+from .utils import flatten
 from .bragg import bragg_angle, cosd, sind
 from .exceptions import MotorDisabled, MotorFaulted, BadN2Pressure
 
-logger = get_logger(__name__, log_file=False)
+logger = logging.getLogger(__name__)
 
 
 class MacroBase(Device):

--- a/hxrsnd/plans.py
+++ b/hxrsnd/plans.py
@@ -23,10 +23,9 @@ from bluesky.utils      import short_uid as _short_uid
 ##########
 # Module #
 ##########
-from .utils import get_logger
 from .errors import UndefinedBounds
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 #Used to strip `run_wrapper` off of plan
 #Should probably be added as bluesky PR

--- a/hxrsnd/pneumatic.py
+++ b/hxrsnd/pneumatic.py
@@ -23,9 +23,8 @@ from pcdsdevices.epics.signal import EpicsSignal, EpicsSignalRO
 ##########
 # Module #
 ##########
-from .utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 class PneuBase(Device):
     """

--- a/hxrsnd/rtd.py
+++ b/hxrsnd/rtd.py
@@ -20,9 +20,8 @@ from pcdsdevices.device import Device
 ##########
 # Module #
 ##########
-from .utils import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class RTDBase(Device):

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -29,13 +29,13 @@ from pcdsdevices.daq import Daq, make_daq_run_engine
 ##########
 from .state import OphydMachine
 from .pneumatic import SndPneumatics
-from .utils import flatten, get_logger
+from .utils import flatten
 from .bragg import bragg_angle, cosd, sind
 from .tower import DelayTower, ChannelCutTower
 from .diode import HamamatsuXMotionDiode, HamamatsuXYMotionCamDiode
 from .macromotor import Energy1Macro, Energy2Macro, DelayMacro
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class SplitAndDelay(Device):

--- a/hxrsnd/state.py
+++ b/hxrsnd/state.py
@@ -10,12 +10,7 @@ from ophyd.device import Device, ComponentMeta
 from super_state_machine.machines import StateMachine
 from super_state_machine.extras  import PropertyMachine
 
-##########
-# Module #
-##########
-from .utils import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class MachineMeta(ComponentMeta):

--- a/hxrsnd/utils.py
+++ b/hxrsnd/utils.py
@@ -75,7 +75,7 @@ def get_logger(name, stream_level=logging.INFO, log_file=True,
     logger.setLevel(logging.DEBUG)
     
     # One format to display the user and another for debugging
-    format_stream = "%(message)4s"
+    format_stream = "%(message)s"
     format_debug = "%(asctime)s:%(filename)s:%(lineno)4s - " \
       "%(funcName)s():    %(levelname)-8s %(message)4s"
     # Prevent logging from propagating to the root logger
@@ -227,3 +227,55 @@ def flatten(inp_iter):
         The contents of the iterable as a flat list
     """
     return list(_flatten(inp_iter))
+
+def as_list(obj, length=None, tp=None, iter_to_list=True):
+    """
+    Force an argument to be a list, optionally of a given length, optionally
+    with all elements cast to a given type if not None.
+
+    Paramters
+    ---------
+    obj : Object
+        The obj we want to convert to a list.
+
+    length : int or None, optional
+        Length of new list. Applies if the inputted obj is not an iterable and
+        iter_to_list is false.
+
+    tp : type, optional
+        Type to cast the values inside the list as.
+
+    iter_to_list : bool, optional
+        Determines if we should cast an iterable (not str) obj as a list or to
+        enclose it in one.
+
+    Returns
+    -------
+    obj : list
+        The object enclosed or cast as a list.
+    """
+    # If the obj is None, return empty list or fixed-length list of Nones
+    if obj is None:
+        if length is None:
+            return []
+        return [None] * length
+    
+    # If it is already a list do nothing
+    elif isinstance(obj, list):
+        pass
+
+    # If it is an iterable (and not str), convert it to a list
+    elif isiterable(obj) and iter_to_list:
+        obj = list(obj)
+        
+    # Otherwise, just enclose in a list making it the inputted length
+    else:
+        try:
+            obj = [obj] * length
+        except TypeError:
+            obj = [obj]
+        
+    # Cast to type; Let exceptions here bubble up to the top.
+    if tp is not None:
+        obj = [tp(o) for o in obj]
+    return obj


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
This adds a new component to the aerotech motors for handling the state, simply called `state`. There is now a new method called `ready_motor` that will clear, enable and change the motor state to go. There were also some bug fixes to the way these "set methods" were handling status objects. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There was no way to control the state pv previously. Also makes it easier to ensure the motor is ready for use.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Simply using the old tests. New tests will be written in the future.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
