### PR TITLE
MAINT: Updating Attocube motor names to use PV aliases

### DIFF
--- a/hxrsnd/aerotech.py
+++ b/hxrsnd/aerotech.py
@@ -3,29 +3,17 @@
 """
 Aerotech devices
 """
-############
-# Standard #
-############
 import logging
 import os
 
-###############
-# Third Party #
-###############
 import numpy as np
 from ophyd import Component, FormattedComponent
 from ophyd.utils import LimitError
 from ophyd.status import wait as status_wait
 
-########
-# SLAC #
-########
 from pcdsdevices.epics.epicsmotor import EpicsMotor
 from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO, FakeSignal)
 
-##########
-# Module #
-##########
 from .pneumatic import PressureSwitch
 from .utils import absolute_submodule_path, as_list
 from .exceptions import MotorDisabled, MotorFaulted, MotorStopped, BadN2Pressure
@@ -734,7 +722,7 @@ class AeroBase(EpicsMotor):
         path = absolute_submodule_path("HXRSnD/screens/motor_expert_screens.sh")
         if print_msg:
             logger.info("Launching expert screen.")
-        os.system("{0} {1} &".format(path, self.prefix))
+        os.system("{0} {1} {2} &".format(path, self.prefix, "aerotech"))
  
     def __call__(self, position, wait=True, ret_status=False, print_move=True,
                  *args, **kwargs):

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -3,31 +3,19 @@
 """
 Attocube devices
 """
-############
-# Standard #
-############
 import os
 import logging
 
-###############
-# Third Party #
-###############
 import numpy as np
 from ophyd import PositionerBase
 from ophyd import Component
 from ophyd.utils import LimitError
 from ophyd.status import wait as status_wait
 
-########
-# SLAC #
-########
 from pcdsdevices.device import Device
 from pcdsdevices.epics.signal import (EpicsSignal, EpicsSignalRO)
 from pcdsdevices.epics.epicsmotor import EpicsMotor
 
-##########
-# Module #
-##########
 from .exceptions import MotorDisabled, MotorError
 from .utils import absolute_submodule_path, as_list
 
@@ -576,17 +564,13 @@ class EccBase(Device, PositionerBase):
         print_msg : bool, optional
             Prints that the screen is being launched.
         """
-        # Get motor info to pass to the screens
-        pv_spl = self.prefix.split(":")
-        act = [s for s in pv_spl[::-1] if s.startswith("ACT")][0]
-        p = ":".join(pv_spl[:pv_spl.index(act)])
-        axis = act[3:]
-
         # Get the absolute path to the screen
         path = absolute_submodule_path("HXRSnD/screens/motor_expert_screens.sh")
         if print_msg:
-            logger.info("Launching expert screen.")        
-        os.system("{0} {1} {2} &".format(path, p, axis))
+            logger.info("Launching expert screen.")
+        os.system("{0} {1} {2} &".format(path, self.prefix, "attocube"))
+    
+        # os.system("{0} {1} {2} &".format(path, p, axis))
 
     def set_limits(self, llm, hlm):
         """

--- a/hxrsnd/attocube.py
+++ b/hxrsnd/attocube.py
@@ -569,8 +569,6 @@ class EccBase(Device, PositionerBase):
         if print_msg:
             logger.info("Launching expert screen.")
         os.system("{0} {1} {2} &".format(path, self.prefix, "attocube"))
-    
-        # os.system("{0} {1} {2} &".format(path, p, axis))
 
     def set_limits(self, llm, hlm):
         """

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -87,12 +87,12 @@ class SplitAndDelay(Device):
         Delay pseudomotor.
     """
     # Delay Towers
-    t1 = Component(DelayTower, ":T1", y1="A:ACT0", y2="A:ACT1",
-                   chi1="A:ACT2", chi2="B:ACT0", dh="B:ACT1",
-                   pos_inserted=21.1, pos_removed=0, desc="Tower 1")
-    t4 = Component(DelayTower, ":T4", y1="C:ACT0", y2="C:ACT1",
-                   chi1="C:ACT2", chi2="D:ACT0", dh="D:ACT1",
-                   pos_inserted=21.1, pos_removed=0, desc="Tower 4")
+    t1 = Component(DelayTower, ":T1", y1="A:M0", y2="A:M1", chi1="A:M2", 
+                   chi2="B:M0", dh="B:M1", pos_inserted=21.1, pos_removed=0, 
+                   desc="Tower 1")
+    t4 = Component(DelayTower, ":T4", y1="C:M0", y2="C:M1", chi1="C:M2", 
+                   chi2="D:M0", dh="D:M1", pos_inserted=21.1, pos_removed=0, 
+                   desc="Tower 4")
 
     # Channel Cut Towers
     t2 = Component(ChannelCutTower, ":T2", pos_inserted=None, 

--- a/hxrsnd/sndsystem.py
+++ b/hxrsnd/sndsystem.py
@@ -3,30 +3,18 @@ Script to hold the split and delay class.
 
 All units of time are in picoseconds, units of length are in mm.
 """
-############
-# Standard #
-############
 import os
 import logging
 
-###############
-# Third Party #
-###############
 import numpy as np
 from ophyd import Component
 from ophyd.status import wait as status_wait
 from ophyd.utils.epics_pvs import raise_if_disconnected
 from bluesky import RunEngine
 
-########
-# SLAC #
-########
 from pcdsdevices.device import Device
 from pcdsdevices.daq import Daq, make_daq_run_engine
 
-##########
-# Module #
-##########
 from .state import OphydMachine
 from .pneumatic import SndPneumatics
 from .utils import flatten, absolute_submodule_path
@@ -87,11 +75,9 @@ class SplitAndDelay(Device):
         Delay pseudomotor.
     """
     # Delay Towers
-    t1 = Component(DelayTower, ":T1", y1="A:M0", y2="A:M1", chi1="A:M2", 
-                   chi2="B:M0", dh="B:M1", pos_inserted=21.1, pos_removed=0, 
+    t1 = Component(DelayTower, ":T1", pos_inserted=21.1, pos_removed=0, 
                    desc="Tower 1")
-    t4 = Component(DelayTower, ":T4", y1="C:M0", y2="C:M1", chi1="C:M2", 
-                   chi2="D:M0", dh="D:M1", pos_inserted=21.1, pos_removed=0, 
+    t4 = Component(DelayTower, ":T4", pos_inserted=21.1, pos_removed=0, 
                    desc="Tower 4")
 
     # Channel Cut Towers

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -1,26 +1,14 @@
 """
 Script for the various tower classes.
 """
-############
-# Standard #
-############
 import logging
 
-###############
-# Third Party #
-###############
 import numpy as np
 from ophyd import Component, FormattedComponent
 from ophyd.status import wait as status_wait
 
-########
-# SLAC #
-########
 from pcdsdevices.device import Device
 
-##########
-# Module #
-##########
 from .rtd import OmegaRTD
 from .diode import HamamatsuDiode
 from .bragg import bragg_angle, bragg_energy
@@ -403,21 +391,16 @@ class DelayTower(TowerBase):
     x = Component(InterLinearAero, ":X", desc="X")
     L = Component(InterLinearAero, ":L", desc="L")
 
-    # Y Crystal motion
-    y1 = FormattedComponent(TranslationEcc, "{self._prefix}:ECC:{self._y1}",
-                            desc="Y1")
-    y2 = FormattedComponent(TranslationEcc, "{self._prefix}:ECC:{self._y2}",
-                            desc="Y2Y")
+    # # Y Crystal motion
+    y1 = Component(TranslationEcc, ":Y1", desc="Y1")
+    y2 = Component(TranslationEcc, ":Y2", desc="Y2")
 
     # Chi motion
-    chi1 = FormattedComponent(GoniometerEcc, "{self._prefix}:ECC:{self._chi1}",
-                              desc="CHI1")
-    chi2 = FormattedComponent(GoniometerEcc, "{self._prefix}:ECC:{self._chi2}",
-                              desc="CHI2")
+    chi1 = Component(GoniometerEcc, ":CHI1", desc="CHI1")
+    chi2 = Component(GoniometerEcc, ":CHI2", desc="CHI2")
 
     # Diode motion
-    dh = FormattedComponent(DiodeEcc, "{self._prefix}:ECC:{self._dh}",
-                            desc="DH")
+    dh = Component(DiodeEcc, ":DH", desc="DH")
     
     # # Diode
     # diode = Component(HamamatsuDiode, ":DIODE", desc="Tower Diode")

--- a/hxrsnd/tower.py
+++ b/hxrsnd/tower.py
@@ -409,14 +409,7 @@ class DelayTower(TowerBase):
     # temp = Component(OmegaRTD, ":TEMP", desc="Tower RTD")
 
     
-    def __init__(self, prefix, y1=None, y2=None, chi1=None, chi2=None, dh=None,
-                 *args, **kwargs):
-        self._y1 = y1 or "Y1"
-        self._y2 = y2 or "Y2"
-        self._chi1 = chi1 or "CHI1"
-        self._chi2 = chi2 or "CHI2"
-        self._dh = dh or "DH"
-        self._prefix = ":".join(prefix.split(":")[:2])
+    def __init__(self, prefix, *args, **kwargs):
         super().__init__(prefix, *args, **kwargs)
         self._energy_motors = [self.tth, self.th1, self.th2]
 

--- a/screens/motor_expert_screens.sh
+++ b/screens/motor_expert_screens.sh
@@ -1,10 +1,9 @@
 # Expert screen launcher.
 # Launches the screens for both the attocube and aerotech motors from the most
 # recently released versions of their respective IOCs. Decides which screen to
-# launch based on the number of parameters passed.
-
-# To use for aerotech motors, simply pass the PV for the motor. For attocube
-# motors, pass the base PV and axis.
+# launch based on the motor name passed in the second argument. For example, if
+# the aerotech motor screen is desired, pass the base PV as the first argument,
+# and "aerotech" as the second argument.
 
 # # # Source the epics env
 # # source /reg/g/pcds/setup/epicsenv-cur.sh
@@ -12,15 +11,15 @@
 # but undone. Sourcing epicsenv-cur cannot happen after entering the conda env
 # otherwise some shared libraries do not load properly.
 
-# If one argument is provided, load the aerotech screens
-if [ "$#" -eq 1 ]; then
+# If "aerotech" is passed as the second argument, load the aerotech screens
+if [ "$2" == "aerotech" ]; then
     # Change directories to the most recent release of ioc/common/aerotech
     cd $(ls -td /reg/g/pcds/package/epics/3.14/ioc/common/aerotech/*/motorScreens | head -1)
     edm -x -eolc -m "MOTOR=${1}" ens_main.edl >& /dev/null &
 
-# If two arguments are provided, load attocube screens
-elif [ "$#" -eq 2 ]; then
-    # Change directories to the most recent release of ioc/common/ecc100    
-    cd $(ls -td /reg/g/pcds/package/epics/3.14/ioc/common/ecc100/*/data | head -1)
-    edm -x -eolc -m "P=${1},axis=${2}" eccStepModule.edl >& /dev/null &
+# If "attocube" is passed as the second argument, load attocube screens
+elif [ "$2" == "attocube" ]; then
+    # Change directories to the most recent release of ioc/common/ecc100
+    cd $(ls -td /reg/g/pcds/package/epics/3.14/ioc/common/ecc100/*/motorScreens | head -1)
+    edm -x -eolc -m "PV=${1}" eccStepModule.edl >& /dev/null &
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
There are PV name changes in the newest attocube IOC that come with aliases which are nicer to work with. This PR simply makes the changes necessary to use the aliases.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We have been running the `1.0.1` release of the attocube IOC when the most recent release is now `1.0.6`. This was necessary to actually use it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Passes all the existing tests.
